### PR TITLE
fix: Fixes broken package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,17 +19,17 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./browser": {
       "types": "./dist/browser.d.ts",
-      "import": "./dist/browser.mjs",
-      "require": "./dist/browser.js"
+      "import": "./dist/browser.js",
+      "require": "./dist/browser.cjs"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
This pull request updates the `package.json` file to improve compatibility with different module systems and clarify build outputs. The most important changes involve switching file extensions for CommonJS and ES modules, which helps consumers of the package use the correct files for their environments.

Module system updates:

* Changed the `exports` field so that `"import"` now points to `.js` files (ES modules) and `"require"` points to `.cjs` files (CommonJS), both for the main entry and the browser build.
* Updated the `main` field to reference the CommonJS build (`index.cjs`) and the `module` field to reference the ES module build (`index.js`).