### PR TITLE
feat: Adds the ability to build glean MCP server names

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,4 +1,5 @@
 import { MCPClientConfig, GleanServerConfig, Platform, validateServerConfig } from './types.js';
+import { buildMcpServerName } from './server-name.js';
 import * as yaml from 'js-yaml';
 
 function isNodeEnvironment(): boolean {
@@ -76,7 +77,10 @@ export class ConfigBuilder {
       throw new Error(`Client ${this.config.id} doesn't support local server configuration`);
     }
 
-    const serverName = gleanConfig.serverName || 'glean';
+    const serverName = buildMcpServerName({
+      mode: 'local',
+      serverName: gleanConfig.serverName
+    });
     const serverConfig: Record<string, unknown> = {};
 
     serverConfig[stdioConfig.commandField] = 'npx';
@@ -176,7 +180,11 @@ export class ConfigBuilder {
 
     const { serverKey, httpConfig, stdioConfig } = this.config.configStructure;
 
-    const serverName = gleanConfig.serverName || 'glean';
+    const serverName = buildMcpServerName({
+      mode: 'remote',
+      serverUrl: gleanConfig.serverUrl,
+      serverName: gleanConfig.serverName
+    });
 
     if (
       httpConfig &&
@@ -258,7 +266,11 @@ export class ConfigBuilder {
       throw new Error(`${this.config.displayName} does not support one-click installation`);
     }
 
-    const serverName = gleanConfig.serverName || 'glean';
+    const serverName = buildMcpServerName({
+      mode: gleanConfig.mode,
+      serverUrl: gleanConfig.serverUrl,
+      serverName: gleanConfig.serverName
+    });
 
     // Build the appropriate config based on the client's capabilities
     let configObj: Record<string, unknown>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './constants.js';
+export * from './server-name.js';
 
 export { ConfigBuilder } from './builder.js';
 export { MCPConfigRegistry } from './registry.js';

--- a/src/server-name.ts
+++ b/src/server-name.ts
@@ -1,0 +1,77 @@
+/**
+ * Centralized server name logic for MCP configurations
+ */
+
+/**
+ * Extracts the server name from a full MCP URL
+ * e.g., https://my-be.glean.com/mcp/analytics -> analytics
+ */
+export function extractServerNameFromUrl(url: string): string | null {
+  const match = url.match(/\/mcp\/([^/]+)(?:\/|$)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Builds a consistent server name for MCP configurations
+ * 
+ * Rules:
+ * - Local mode: 'glean_local'
+ * - Agents mode: 'glean_agents'
+ * - Remote with URL ending in /mcp/default: 'glean_default' (for consistency)
+ * - Remote with other URLs: 'glean_<extracted-name>'
+ * - Fallback: 'glean'
+ */
+export function buildMcpServerName(options: {
+  mode?: 'local' | 'remote';
+  serverUrl?: string;
+  serverName?: string;
+  agents?: boolean;
+}): string {
+  // If explicit server name is provided, use it with prefix
+  if (options.serverName) {
+    // If it already starts with glean or glean_, don't double-prefix
+    if (options.serverName === 'glean' || options.serverName.startsWith('glean_')) {
+      return options.serverName;
+    }
+    return `glean_${options.serverName}`;
+  }
+
+  // Local mode
+  if (options.mode === 'local') {
+    return 'glean_local';
+  }
+
+  // Agents mode
+  if (options.agents) {
+    return 'glean_agents';
+  }
+
+  // Remote mode with URL
+  if (options.mode === 'remote' && options.serverUrl) {
+    const extracted = extractServerNameFromUrl(options.serverUrl);
+    if (extracted) {
+      // Consistent behavior: always prefix with glean_
+      return `glean_${extracted}`;
+    }
+  }
+
+  // Default fallback
+  return 'glean';
+}
+
+/**
+ * Normalizes a server name to ensure consistency
+ * This is useful when accepting user input that might not follow conventions
+ */
+export function normalizeServerName(name: string): string {
+  // Remove any existing glean prefix to avoid duplication
+  const withoutPrefix = name.replace(/^glean_?/i, '');
+  
+  // If it's empty after removing prefix, return default
+  if (!withoutPrefix) {
+    return 'glean';
+  }
+  
+  // Apply consistent formatting
+  return `glean_${withoutPrefix.toLowerCase()}`;
+}

--- a/test/browser-build.test.ts
+++ b/test/browser-build.test.ts
@@ -72,7 +72,7 @@ describe('Browser Build', () => {
 
     const cursorUrl = cursorBuilder.buildOneClickUrl(config);
     expect(cursorUrl).toContain('cursor://anysphere.cursor-deeplink/mcp/install');
-    expect(cursorUrl).toContain('name=test-server');
+    expect(cursorUrl).toContain('name=glean_test-server');
     expect(cursorUrl).toContain('config=');
   });
 });

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -33,7 +33,7 @@ describe('ConfigBuilder', () => {
       const urlObj = new URL(url.replace('cursor://', 'https://'));
       expect(urlObj.hostname).toBe('anysphere.cursor-deeplink');
       expect(urlObj.pathname).toBe('/mcp/install');
-      expect(urlObj.searchParams.get('name')).toBe('test-server');
+      expect(urlObj.searchParams.get('name')).toBe('glean_test-server');
 
       const encodedConfig = urlObj.searchParams.get('config');
       const decodedConfig = JSON.parse(Buffer.from(encodedConfig!, 'base64').toString());
@@ -185,7 +185,7 @@ describe('ConfigBuilder', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "mcpServers": {
-            "glean": {
+            "glean_local": {
               "args": [
                 "-y",
                 "@gleanwork/local-mcp-server",
@@ -212,7 +212,7 @@ describe('ConfigBuilder', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "mcpServers": {
-            "glean": {
+            "glean_local": {
               "args": [
                 "-y",
                 "@gleanwork/local-mcp-server",
@@ -298,8 +298,8 @@ describe('ConfigBuilder', () => {
 
       expect(config).toMatchInlineSnapshot(`
         "extensions:
-          test:
-            name: test
+          glean_test:
+            name: glean_test
             cmd: npx
             args:
               - '-y'
@@ -332,7 +332,7 @@ describe('ConfigBuilder', () => {
       expect(parsed).toMatchInlineSnapshot(`
         {
           "mcpServers": {
-            "test": {
+            "glean_test": {
               "type": "http",
               "url": "https://example.com/mcp/default",
             },
@@ -357,7 +357,7 @@ describe('ConfigBuilder', () => {
       expect(parsed).toMatchInlineSnapshot(`
         {
           "mcpServers": {
-            "test": {
+            "glean_test": {
               "type": "http",
               "url": "https://example.com/mcp/default",
             },
@@ -381,7 +381,7 @@ describe('ConfigBuilder', () => {
       expect(parsed).toMatchInlineSnapshot(`
         {
           "mcpServers": {
-            "glean": {
+            "glean_default": {
               "type": "http",
               "url": "https://example.com/mcp/default",
             },
@@ -406,7 +406,7 @@ describe('ConfigBuilder', () => {
       expect(parsed).toMatchInlineSnapshot(`
         {
           "mcpServers": {
-            "glean": {
+            "glean_local": {
               "args": [
                 "-y",
                 "@gleanwork/local-mcp-server",
@@ -450,7 +450,7 @@ describe('ConfigBuilder', () => {
       expect(Object.keys(generatedConfig)[0]).toBe(jsonConfig.configStructure.serverKey);
       expect(generatedConfig).toHaveProperty('servers'); // VS Code uses 'servers'
 
-      const serverConfig = generatedConfig.servers.test;
+      const serverConfig = generatedConfig.servers.glean_test;
       expect(serverConfig).toHaveProperty(jsonConfig.configStructure.httpConfig.typeField);
       expect(serverConfig).toHaveProperty(jsonConfig.configStructure.httpConfig.urlField);
     });
@@ -472,7 +472,7 @@ describe('ConfigBuilder', () => {
       expect(Object.keys(generatedConfig)[0]).toBe(jsonConfig.configStructure.serverKey);
       expect(generatedConfig).toHaveProperty('extensions'); // Goose uses 'extensions'
 
-      const serverConfig = generatedConfig.extensions.test;
+      const serverConfig = generatedConfig.extensions.glean_test;
       expect(serverConfig).toHaveProperty(jsonConfig.configStructure.stdioConfig.commandField); // 'cmd' for Goose
       expect(serverConfig.cmd).toBe('npx'); // Should use 'cmd' not 'command'
     });
@@ -490,9 +490,9 @@ describe('ConfigBuilder', () => {
         })
       );
 
-      expect(generatedConfig.mcpServers.test).not.toHaveProperty('type');
-      expect(generatedConfig.mcpServers.test).toHaveProperty('command');
-      expect(generatedConfig.mcpServers.test).toHaveProperty('args');
+      expect(generatedConfig.mcpServers.glean_test).not.toHaveProperty('type');
+      expect(generatedConfig.mcpServers.glean_test).toHaveProperty('command');
+      expect(generatedConfig.mcpServers.glean_test).toHaveProperty('args');
     });
 
     it('should use platform-specific paths from JSON config', () => {
@@ -750,7 +750,7 @@ describe('ConfigBuilder', () => {
         const result = JSON.parse(builder.buildConfiguration(config));
 
         expect(result).toHaveProperty('mcpServers');
-        expect(result.mcpServers).toHaveProperty('test');
+        expect(result.mcpServers).toHaveProperty('glean_test');
       });
 
       it('should include wrapper when includeWrapper is explicitly true', () => {
@@ -765,7 +765,7 @@ describe('ConfigBuilder', () => {
         const result = JSON.parse(builder.buildConfiguration(config));
 
         expect(result).toHaveProperty('mcpServers');
-        expect(result.mcpServers).toHaveProperty('test');
+        expect(result.mcpServers).toHaveProperty('glean_test');
       });
 
       it('should maintain backward compatibility for VS Code', () => {
@@ -779,7 +779,7 @@ describe('ConfigBuilder', () => {
         const result = JSON.parse(builder.buildConfiguration(config));
 
         expect(result).toHaveProperty('servers');
-        expect(result.servers).toHaveProperty('test');
+        expect(result.servers).toHaveProperty('glean_test');
       });
 
       it('should maintain backward compatibility for Goose', () => {
@@ -794,7 +794,7 @@ describe('ConfigBuilder', () => {
         const result = yaml.load(yamlResult) as Record<string, unknown>;
 
         expect(result).toHaveProperty('extensions');
-        expect(result.extensions).toHaveProperty('test');
+        expect(result.extensions).toHaveProperty('glean_test');
       });
     });
 
@@ -809,7 +809,7 @@ describe('ConfigBuilder', () => {
 
         const result = JSON.parse(builder.buildConfiguration(config));
 
-        expect(result).toHaveProperty('glean');
+        expect(result).toHaveProperty('glean_default');
         expect(result).not.toHaveProperty('mcpServers');
       });
 
@@ -823,14 +823,14 @@ describe('ConfigBuilder', () => {
         const result = JSON.parse(builder.buildConfiguration(config));
 
         expect(result).toEqual({
-          glean: {
+          glean_local: {
             type: 'stdio',
             command: 'npx',
             args: ['-y', '@gleanwork/local-mcp-server'],
           },
         });
 
-        expect(result.glean).not.toHaveProperty('env');
+        expect(result.glean_local).not.toHaveProperty('env');
       });
     });
   });

--- a/test/server-name.test.ts
+++ b/test/server-name.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractServerNameFromUrl,
+  buildMcpServerName,
+  normalizeServerName,
+} from '../src/server-name';
+
+describe('Server Name Logic', () => {
+  describe('extractServerNameFromUrl', () => {
+    it('extracts server name from standard MCP URL', () => {
+      expect(extractServerNameFromUrl('https://my-be.glean.com/mcp/analytics')).toBe('analytics');
+      expect(extractServerNameFromUrl('https://my-be.glean.com/mcp/default')).toBe('default');
+      expect(extractServerNameFromUrl('https://my-be.glean.com/mcp/custom-agent')).toBe(
+        'custom-agent'
+      );
+    });
+
+    it('handles URLs with trailing slashes', () => {
+      expect(extractServerNameFromUrl('https://my-be.glean.com/mcp/analytics/')).toBe('analytics');
+      expect(extractServerNameFromUrl('https://my-be.glean.com/mcp/default/')).toBe('default');
+    });
+
+    it('handles URLs with additional path segments', () => {
+      expect(extractServerNameFromUrl('https://my-be.glean.com/mcp/analytics/v1')).toBe(
+        'analytics'
+      );
+    });
+
+    it('returns null for URLs without MCP path', () => {
+      expect(extractServerNameFromUrl('https://my-be.glean.com/api/v1')).toBeNull();
+      expect(extractServerNameFromUrl('https://my-be.glean.com/')).toBeNull();
+    });
+  });
+
+  describe('buildMcpServerName', () => {
+    describe('local mode', () => {
+      it('returns glean_local for local mode', () => {
+        expect(buildMcpServerName({ mode: 'local' })).toBe('glean_local');
+      });
+
+      it('returns glean_local even with custom serverName in local mode', () => {
+        expect(buildMcpServerName({ mode: 'local', serverName: 'custom' })).toBe('glean_custom');
+      });
+    });
+
+    describe('agents mode', () => {
+      it('returns glean_agents when agents flag is set', () => {
+        expect(buildMcpServerName({ agents: true })).toBe('glean_agents');
+      });
+
+      it('prioritizes agents over serverUrl', () => {
+        expect(
+          buildMcpServerName({
+            agents: true,
+            serverUrl: 'https://my-be.glean.com/mcp/analytics',
+          })
+        ).toBe('glean_agents');
+      });
+    });
+
+    describe('remote mode with URL', () => {
+      it('extracts and prefixes server name from URL', () => {
+        expect(
+          buildMcpServerName({
+            mode: 'remote',
+            serverUrl: 'https://my-be.glean.com/mcp/analytics',
+          })
+        ).toBe('glean_analytics');
+      });
+
+      it('returns glean_default for default endpoint (consistent behavior)', () => {
+        expect(
+          buildMcpServerName({
+            mode: 'remote',
+            serverUrl: 'https://my-be.glean.com/mcp/default',
+          })
+        ).toBe('glean_default');
+      });
+
+      it('handles custom-agent URLs', () => {
+        expect(
+          buildMcpServerName({
+            mode: 'remote',
+            serverUrl: 'https://my-be.glean.com/mcp/custom-agent',
+          })
+        ).toBe('glean_custom-agent');
+      });
+    });
+
+    describe('explicit serverName', () => {
+      it('uses explicit serverName with prefix', () => {
+        expect(buildMcpServerName({ serverName: 'custom' })).toBe('glean_custom');
+        expect(buildMcpServerName({ serverName: 'analytics' })).toBe('glean_analytics');
+      });
+
+      it('does not double-prefix if serverName already has glean prefix', () => {
+        expect(buildMcpServerName({ serverName: 'glean_custom' })).toBe('glean_custom');
+        expect(buildMcpServerName({ serverName: 'glean' })).toBe('glean');
+      });
+
+      it('explicit serverName overrides URL extraction', () => {
+        expect(
+          buildMcpServerName({
+            mode: 'remote',
+            serverUrl: 'https://my-be.glean.com/mcp/analytics',
+            serverName: 'custom',
+          })
+        ).toBe('glean_custom');
+      });
+    });
+
+    describe('fallback behavior', () => {
+      it('returns glean as default fallback', () => {
+        expect(buildMcpServerName({})).toBe('glean');
+        expect(buildMcpServerName({ mode: 'remote' })).toBe('glean');
+      });
+    });
+  });
+
+  describe('normalizeServerName', () => {
+    it('adds glean_ prefix to names without it', () => {
+      expect(normalizeServerName('custom')).toBe('glean_custom');
+      expect(normalizeServerName('analytics')).toBe('glean_analytics');
+    });
+
+    it('does not double-prefix names that already have glean_', () => {
+      expect(normalizeServerName('glean_custom')).toBe('glean_custom');
+      expect(normalizeServerName('glean_analytics')).toBe('glean_analytics');
+    });
+
+    it('handles names that start with just glean', () => {
+      expect(normalizeServerName('glean')).toBe('glean');
+      expect(normalizeServerName('gleancustom')).toBe('glean_custom');
+    });
+
+    it('converts to lowercase', () => {
+      expect(normalizeServerName('CUSTOM')).toBe('glean_custom');
+      expect(normalizeServerName('Glean_Analytics')).toBe('glean_analytics');
+    });
+
+    it('handles edge cases', () => {
+      expect(normalizeServerName('')).toBe('glean');
+      expect(normalizeServerName('glean_')).toBe('glean');
+    });
+  });
+});


### PR DESCRIPTION
### Code changes:
* Added a new function `buildMcpServerName` to centralize the logic of generating consistent server names for different modes (local and remote) and scenarios, ensuring all server names follow the defined rules. This function replaces usages of directly assigning a fallback server name with descriptive logic based on provided options.
