### PR TITLE
feat: Adds claude desktop linux support

### DIFF
--- a/configs/claude-desktop.json
+++ b/configs/claude-desktop.json
@@ -8,11 +8,12 @@
   "documentationUrl": "https://docs.anthropic.com/en/docs/claude-desktop",
   "clientSupports": "stdio-only",
   "requiresMcpRemoteForHttp": true,
-  "supportedPlatforms": ["darwin", "win32"],
+  "supportedPlatforms": ["darwin", "win32", "linux"],
   "configFormat": "json",
   "configPath": {
     "darwin": "$HOME/Library/Application Support/Claude/claude_desktop_config.json",
-    "win32": "%APPDATA%\\Claude\\claude_desktop_config.json"
+    "win32": "%APPDATA%\\Claude\\claude_desktop_config.json",
+    "linux": "$HOME/.config/Claude/claude_desktop_config.json"
   },
   "configStructure": {
     "serverKey": "mcpServers",

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -275,10 +275,19 @@ describe('ConfigBuilder', () => {
       expect(config?.configStructure.stdioConfig?.typeField).toBeUndefined();
     });
 
-    it('should handle Claude Desktop which has no Linux support', () => {
+    it('should handle Claude Desktop with Linux support', () => {
       const config = registry.getConfig(CLIENT.CLAUDE_DESKTOP);
-      expect(config?.supportedPlatforms).toEqual(['darwin', 'win32']);
-      expect(config?.supportedPlatforms).not.toContain('linux');
+      expect(config?.supportedPlatforms).toEqual(['darwin', 'win32', 'linux']);
+      expect(config?.supportedPlatforms).toContain('linux');
+    });
+
+    it('should have correct platform-specific paths for Claude Desktop', () => {
+      const config = registry.getConfig(CLIENT.CLAUDE_DESKTOP);
+      expect(config?.configPath.darwin).toBe(
+        '$HOME/Library/Application Support/Claude/claude_desktop_config.json'
+      );
+      expect(config?.configPath.win32).toBe('%APPDATA%\\Claude\\claude_desktop_config.json');
+      expect(config?.configPath.linux).toBe('$HOME/.config/Claude/claude_desktop_config.json');
     });
   });
 

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -105,7 +105,8 @@ describe('MCPConfigRegistry', () => {
 
       const claudeDesktop = registry.getConfig(CLIENT.CLAUDE_DESKTOP);
       expect(darwinClients).toContainEqual(claudeDesktop);
-      expect(linuxClients).not.toContainEqual(claudeDesktop);
+      expect(linuxClients).toContainEqual(claudeDesktop);
+      expect(win32Clients).toContainEqual(claudeDesktop);
     });
   });
 });


### PR DESCRIPTION
### Code changes:
* Added support for the Linux platform in the Claude Desktop configuration by modifying the `supportedPlatforms`, updated the configuration paths accordingly, and adjusted the test cases to reflect these changes. The changes include the addition of "linux" as a supported platform in the configuration file and its respective config path.
