### PR TITLE
feat: Adds buildCommand function to centralize CLI configuration command building

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -85,3 +85,16 @@ export function clientSupportsHttpNatively(clientId: ClientId): boolean {
 export function clientSupportsStdio(clientId: ClientId): boolean {
   return registry.clientSupportsStdio(clientId);
 }
+
+/**
+ * Convenience function to build a CLI command for installing an MCP server
+ * without needing to instantiate the registry directly.
+ *
+ * @param clientId - The client to build the command for
+ * @param serverData - The server configuration data
+ * @returns The CLI command string, or null if the client doesn't support CLI installation
+ */
+export function buildCommand(clientId: ClientId, serverData: GleanServerConfig): string | null {
+  const builder = registry.createBuilder(clientId);
+  return builder.buildCommand(serverData);
+}

--- a/src/builders/BaseConfigBuilder.ts
+++ b/src/builders/BaseConfigBuilder.ts
@@ -88,6 +88,19 @@ export abstract class BaseConfigBuilder {
 
   buildOneClickUrl?(serverData: GleanServerConfig): string;
 
+  buildCommand(serverData: GleanServerConfig): string | null {
+    const validatedConfig = validateServerConfig(serverData);
+
+    if (validatedConfig.transport === 'http') {
+      return this.buildRemoteCommand(validatedConfig);
+    } else {
+      return this.buildLocalCommand(validatedConfig);
+    }
+  }
+
+  protected abstract buildRemoteCommand(serverData: GleanServerConfig): string | null;
+  protected abstract buildLocalCommand(serverData: GleanServerConfig): string | null;
+
   abstract getNormalizedServersConfig(config: Record<string, unknown>): Record<string, unknown>;
 
   getConfigPath(): string {

--- a/src/builders/ClaudeCodeConfigBuilder.ts
+++ b/src/builders/ClaudeCodeConfigBuilder.ts
@@ -1,0 +1,63 @@
+import { GenericConfigBuilder } from './GenericConfigBuilder.js';
+import { GleanServerConfig } from '../types.js';
+import { buildMcpServerName } from '../server-name.js';
+
+export class ClaudeCodeConfigBuilder extends GenericConfigBuilder {
+  protected buildRemoteCommand(serverData: GleanServerConfig): string {
+    if (!serverData.serverUrl) {
+      throw new Error('Remote configuration requires serverUrl');
+    }
+
+    const serverName = buildMcpServerName({
+      transport: serverData.transport,
+      serverUrl: serverData.serverUrl,
+      serverName: serverData.serverName,
+    });
+
+    let command = `claude mcp add ${serverName} ${serverData.serverUrl} --transport http`;
+
+    // Claude Code uses --header flag for auth
+    if (serverData.apiToken) {
+      command += ` --header "Authorization: Bearer ${serverData.apiToken}"`;
+    }
+
+    return command;
+  }
+
+  protected buildLocalCommand(serverData: GleanServerConfig): string {
+    // Claude Code doesn't have a native local command, fall back to configure-mcp-server
+    return this.buildConfigureMcpServerCommand(serverData, 'local');
+  }
+
+  private buildConfigureMcpServerCommand(
+    serverData: GleanServerConfig,
+    mode: 'local' | 'remote'
+  ): string {
+    let command = `npx -y @gleanwork/configure-mcp-server ${mode}`;
+
+    if (mode === 'remote') {
+      if (!serverData.serverUrl) {
+        throw new Error('Remote configuration requires serverUrl');
+      }
+      command += ` --url ${serverData.serverUrl}`;
+    } else {
+      if (!serverData.instance) {
+        throw new Error('Local configuration requires instance');
+      }
+      // Handle instance URL vs instance name
+      if (serverData.instance.startsWith('http://') || serverData.instance.startsWith('https://')) {
+        command += ` --url ${serverData.instance}`;
+      } else {
+        command += ` --instance ${serverData.instance}`;
+      }
+    }
+
+    command += ` --client ${this.config.id}`;
+
+    if (serverData.apiToken) {
+      command += ` --token ${serverData.apiToken}`;
+    }
+
+    return command;
+  }
+}

--- a/src/builders/CursorConfigBuilder.ts
+++ b/src/builders/CursorConfigBuilder.ts
@@ -56,6 +56,46 @@ export class CursorConfigBuilder extends GenericConfigBuilder {
       .replace('{{config}}', encodedConfig);
   }
 
+  protected buildRemoteCommand(serverData: GleanServerConfig): string {
+    if (!serverData.serverUrl) {
+      throw new Error('Remote configuration requires serverUrl');
+    }
+
+    // Cursor doesn't have native CLI, use configure-mcp-server
+    let command = `npx -y @gleanwork/configure-mcp-server remote`;
+    command += ` --url ${serverData.serverUrl}`;
+    command += ` --client cursor`;
+
+    if (serverData.apiToken) {
+      command += ` --token ${serverData.apiToken}`;
+    }
+
+    return command;
+  }
+
+  protected buildLocalCommand(serverData: GleanServerConfig): string {
+    if (!serverData.instance) {
+      throw new Error('Local configuration requires instance');
+    }
+
+    let command = `npx -y @gleanwork/configure-mcp-server local`;
+
+    // Handle instance URL vs instance name
+    if (serverData.instance.startsWith('http://') || serverData.instance.startsWith('https://')) {
+      command += ` --url ${serverData.instance}`;
+    } else {
+      command += ` --instance ${serverData.instance}`;
+    }
+
+    command += ` --client cursor`;
+
+    if (serverData.apiToken) {
+      command += ` --token ${serverData.apiToken}`;
+    }
+
+    return command;
+  }
+
   getNormalizedServersConfig(config: Record<string, unknown>): Record<string, unknown> {
     const { serverKey } = this.config.configStructure;
 

--- a/src/builders/GooseConfigBuilder.ts
+++ b/src/builders/GooseConfigBuilder.ts
@@ -159,6 +159,46 @@ export class GooseConfigBuilder extends BaseConfigBuilder {
     }
   }
 
+  protected buildRemoteCommand(serverData: GleanServerConfig): string {
+    if (!serverData.serverUrl) {
+      throw new Error('Remote configuration requires serverUrl');
+    }
+
+    // Goose is supported by configure-mcp-server
+    let command = `npx -y @gleanwork/configure-mcp-server remote`;
+    command += ` --url ${serverData.serverUrl}`;
+    command += ` --client goose`;
+
+    if (serverData.apiToken) {
+      command += ` --token ${serverData.apiToken}`;
+    }
+
+    return command;
+  }
+
+  protected buildLocalCommand(serverData: GleanServerConfig): string {
+    if (!serverData.instance) {
+      throw new Error('Local configuration requires instance');
+    }
+
+    let command = `npx -y @gleanwork/configure-mcp-server local`;
+
+    // Handle instance URL vs instance name
+    if (serverData.instance.startsWith('http://') || serverData.instance.startsWith('https://')) {
+      command += ` --url ${serverData.instance}`;
+    } else {
+      command += ` --instance ${serverData.instance}`;
+    }
+
+    command += ` --client goose`;
+
+    if (serverData.apiToken) {
+      command += ` --token ${serverData.apiToken}`;
+    }
+
+    return command;
+  }
+
   getNormalizedServersConfig(config: Record<string, unknown>): Record<string, unknown> {
     // Goose uses extensions wrapper
     if (config['extensions']) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ export { GenericConfigBuilder } from './builders/GenericConfigBuilder.js';
 export { VSCodeConfigBuilder } from './builders/VSCodeConfigBuilder.js';
 export { GooseConfigBuilder } from './builders/GooseConfigBuilder.js';
 export { CursorConfigBuilder } from './builders/CursorConfigBuilder.js';
+export { ClaudeCodeConfigBuilder } from './builders/ClaudeCodeConfigBuilder.js';
 export {
   buildConfiguration,
   buildConfigurationString,
   buildOneClickUrl,
+  buildCommand,
   clientNeedsMcpRemote,
   clientSupportsHttpNatively,
   clientSupportsStdio,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,6 +5,7 @@ import { GenericConfigBuilder } from './builders/GenericConfigBuilder.js';
 import { GooseConfigBuilder } from './builders/GooseConfigBuilder.js';
 import { VSCodeConfigBuilder } from './builders/VSCodeConfigBuilder.js';
 import { CursorConfigBuilder } from './builders/CursorConfigBuilder.js';
+import { ClaudeCodeConfigBuilder } from './builders/ClaudeCodeConfigBuilder.js';
 import chatgptConfig from '../configs/chatgpt.json';
 import claudeCodeConfig from '../configs/claude-code.json';
 import claudeDesktopConfig from '../configs/claude-desktop.json';
@@ -47,6 +48,10 @@ export class MCPConfigRegistry {
     this.builderFactories.set(
       'cursor' as ClientId,
       CursorConfigBuilder as new (config: MCPClientConfig) => BaseConfigBuilder
+    );
+    this.builderFactories.set(
+      'claude-code' as ClientId,
+      ClaudeCodeConfigBuilder as new (config: MCPClientConfig) => BaseConfigBuilder
     );
     // Other clients will use GenericConfigBuilder by default
   }


### PR DESCRIPTION
### Code changes:
* A new `buildCommand` function has been added to centralize the command-building logic for CLI configuration across various client builders. This function streamlines the process of generating commands for both remote and local server setups based on the client's transport type, improving maintainability and code organization. Additionally, it initiates the creation of a `ClaudeCodeConfigBuilder` along with adjustments in existing builders to accommodate these changes.
