### PR TITLE
fix: Updates our one click url generator to not rely on Buffer for browser envs

### DIFF
--- a/src/builders/BaseConfigBuilder.ts
+++ b/src/builders/BaseConfigBuilder.ts
@@ -147,6 +147,23 @@ export abstract class BaseConfigBuilder {
     return LOCAL_MCP_SERVER_PACKAGE;
   }
 
+  /**
+   * Encodes a string to base64 in a way that works in both Node.js and browsers.
+   * Handles Unicode characters properly.
+   */
+  protected toBase64(str: string): string {
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(str).toString('base64');
+    } else if (typeof btoa !== 'undefined') {
+      const bytes = new TextEncoder().encode(str);
+      const binary = String.fromCharCode(...bytes);
+
+      return btoa(binary);
+    } else {
+      throw new Error('No base64 encoding method available');
+    }
+  }
+
   abstract getNormalizedServersConfig(config: Record<string, unknown>): Record<string, unknown>;
 
   getConfigPath(): string {

--- a/src/builders/CursorConfigBuilder.ts
+++ b/src/builders/CursorConfigBuilder.ts
@@ -45,7 +45,7 @@ export class CursorConfigBuilder extends GenericConfigBuilder {
       }
     }
 
-    const encodedConfig = Buffer.from(JSON.stringify(config)).toString('base64');
+    const encodedConfig = this.toBase64(JSON.stringify(config));
 
     return this.config.oneClick.urlTemplate
       .replace('{{name}}', encodeURIComponent(serverName))


### PR DESCRIPTION
### Code changes:
* The update replaces direct usage of the `Buffer` class for base64 encoding in browser environments with a new `toBase64` method. This method first checks the execution environment to use the appropriate encoding strategy, ensuring compatibility with both Node.js and browsers while correctly handling Unicode characters. 

This change improves cross-environment compatibility for base64 encoding by providing a more robust and adaptive solution.
