### PR TITLE
refactor: Move zod to peerDependencies to support v3 and v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "chalk": "^5.3.0",
         "glob": "^10.3.10",
         "js-yaml": "^4.1.0",
-        "mkdirp": "^3.0.1",
-        "zod": "^4.0.17"
+        "mkdirp": "^3.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -36,10 +35,14 @@
         "tsup": "^8.0.1",
         "tsx": "^4.20.4",
         "typescript": "^5.3.3",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "zod": "^4.1.11"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11353,6 +11356,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "chalk": "^5.3.0",
     "glob": "^10.3.10",
     "js-yaml": "^4.1.0",
-    "mkdirp": "^3.0.1",
-    "zod": "^4.0.17"
+    "mkdirp": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
@@ -82,10 +81,14 @@
     "tsup": "^8.0.1",
     "tsx": "^4.20.4",
     "typescript": "^5.3.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "zod": "^4.1.11"
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Move zod from regular dependencies to devDependencies + peerDependencies. This allows consumers to use either zod v3.25+ or v4.0+ based on their needs, avoiding version conflicts and reducing bundle size by not forcing a specific version. Zod remains in devDependencies for development and testing.

**NOTE:** I labeled this as a breaking change, mostly because it requires that consumers bring the `zod`.