### PR TITLE
feat(glean)!: drop local MCP path; add cliVersion pin support

### DIFF
--- a/packages/mcp-config-glean/README.md
+++ b/packages/mcp-config-glean/README.md
@@ -15,20 +15,13 @@ npm install @gleanwork/mcp-config-glean
 ```typescript
 import {
   createGleanRegistry,
-  createGleanServerUrlEnv,
   createGleanHeaders,
   buildGleanMcpUrl,
 } from '@gleanwork/mcp-config-glean';
 
-// Create a pre-configured registry
+// Create a pre-configured registry (remote / HTTP only)
 const registry = createGleanRegistry();
 const builder = registry.createBuilder('cursor');
-
-// Generate stdio configuration
-const stdioConfig = builder.buildConfiguration({
-  transport: 'stdio',
-  env: createGleanServerUrlEnv('https://my-company-be.glean.com', 'my-api-token'),
-});
 
 // Generate HTTP configuration
 const httpConfig = builder.buildConfiguration({
@@ -36,6 +29,15 @@ const httpConfig = builder.buildConfiguration({
   serverUrl: buildGleanMcpUrl('https://my-company-be.glean.com'),
   headers: createGleanHeaders('my-api-token'),
 });
+
+// Pin the CLI version in generated install commands
+const command = builder.buildCommand({
+  transport: 'http',
+  serverUrl: buildGleanMcpUrl('https://my-company-be.glean.com'),
+  headers: createGleanHeaders('my-api-token'),
+  cliVersion: '3.1.0',
+});
+// -> `npx -y @gleanwork/configure-mcp-server@3.1.0 remote --url ... --client cursor --token ...`
 ```
 
 ### Available Exports
@@ -45,8 +47,7 @@ const httpConfig = builder.buildConfiguration({
 ```typescript
 import { GLEAN_REGISTRY_OPTIONS, GLEAN_ENV } from '@gleanwork/mcp-config-glean';
 
-// Registry options for Glean MCP server
-GLEAN_REGISTRY_OPTIONS.serverPackage     // '@gleanwork/local-mcp-server'
+// Registry options for Glean's remote MCP server (HTTP only)
 GLEAN_REGISTRY_OPTIONS.tokenEnvVarName   // 'GLEAN_API_TOKEN'
 GLEAN_REGISTRY_OPTIONS.commandBuilder    // Functions to generate CLI commands
 GLEAN_REGISTRY_OPTIONS.serverNameBuilder // Callback that prefixes server names with glean_
@@ -84,7 +85,6 @@ normalizeGleanProductName();              // 'glean'
 normalizeGleanProductName('Acme Corp');   // 'acme_corp'
 
 // Build server names with glean_ prefix
-buildGleanServerName({ transport: 'stdio' });                              // 'glean_local'
 buildGleanServerName({ transport: 'http' });                               // 'glean_default'
 buildGleanServerName({ transport: 'http', serverUrl: '.../mcp/analytics' }); // 'glean_analytics'
 buildGleanServerName({ serverName: 'custom' });                            // 'glean_custom'

--- a/packages/mcp-config-glean/src/index.ts
+++ b/packages/mcp-config-glean/src/index.ts
@@ -29,18 +29,24 @@ export const GLEAN_ENV = {
 } as const;
 
 /**
- * Glean-specific registry options for stdio transport.
+ * Glean-specific registry options.
+ *
+ * This registry only supports the remote (HTTP) transport. Local/stdio
+ * installation is intentionally not offered: `serverPackage` is omitted so
+ * that `buildConfiguration({ transport: 'stdio' })` throws, and the stdio
+ * command builder is not registered so `buildCommand` returns null for stdio.
  */
 export const GLEAN_REGISTRY_OPTIONS: RegistryOptions = {
-  serverPackage: '@gleanwork/local-mcp-server',
   tokenEnvVarName: GLEAN_ENV.API_TOKEN,
   commandBuilder: {
     http: (clientId, options) => {
       if (!options.serverUrl) return null;
 
-      let command = `npx -y @gleanwork/configure-mcp-server remote --url ${options.serverUrl} --client ${clientId}`;
+      const pkg = options.cliVersion
+        ? `@gleanwork/configure-mcp-server@${options.cliVersion}`
+        : '@gleanwork/configure-mcp-server';
+      let command = `npx -y ${pkg} remote --url ${options.serverUrl} --client ${clientId}`;
 
-      // Extract token from Authorization header if present
       const authHeader = options.headers?.['Authorization'];
       if (authHeader?.startsWith('Bearer ')) {
         const token = authHeader.slice(7);
@@ -49,15 +55,8 @@ export const GLEAN_REGISTRY_OPTIONS: RegistryOptions = {
 
       return command;
     },
-    stdio: (clientId, options) => {
-      const envFlags = Object.entries(options.env || {})
-        .map(([k, v]) => `--env ${k}=${v}`)
-        .join(' ');
-      return `npx -y @gleanwork/configure-mcp-server local --client ${clientId}${envFlags ? ` ${envFlags}` : ''}`;
-    },
   },
   serverNameBuilder: (options) => {
-    // Lazily call buildGleanServerName defined below
     return buildGleanServerName(options);
   },
 };
@@ -95,17 +94,14 @@ export function createGleanUrlEnv(url: string, apiToken?: string): Record<string
 /**
  * Helper to create Glean environment variables using a server URL.
  *
+ * Populates the env vars consumed by any Glean-aware MCP server or CLI that
+ * reads `GLEAN_SERVER_URL` / `GLEAN_API_TOKEN` (e.g., a self-hosted stdio
+ * server). This package's own registry is remote-only and does not consume
+ * these env vars.
+ *
  * @param serverUrl - Full Glean server URL (e.g., 'https://my-company-be.glean.com')
  * @param apiToken - Optional API token
- * @returns Environment variables object for use in MCPConnectionOptions.env
- *
- * @example
- * ```typescript
- * const config = builder.buildConfiguration({
- *   transport: 'stdio',
- *   env: createGleanServerUrlEnv('https://my-company-be.glean.com', 'my-api-token'),
- * });
- * ```
+ * @returns Env-var object suitable for a child process' environment
  */
 export function createGleanServerUrlEnv(
   serverUrl: string,
@@ -139,22 +135,15 @@ export function createGleanHeaders(apiToken: string): Record<string, string> {
 }
 
 /**
- * Create an MCPConfigRegistry pre-configured with Glean defaults.
+ * Create an MCPConfigRegistry pre-configured with Glean defaults (remote/HTTP only).
  *
- * @returns MCPConfigRegistry configured for Glean stdio transport
+ * @returns MCPConfigRegistry configured for Glean's remote MCP server
  *
  * @example
  * ```typescript
  * const registry = createGleanRegistry();
  * const builder = registry.createBuilder('cursor');
  *
- * // For stdio transport
- * const config = builder.buildConfiguration({
- *   transport: 'stdio',
- *   env: createGleanServerUrlEnv('https://my-company-be.glean.com', 'my-api-token'),
- * });
- *
- * // For HTTP transport
  * const httpConfig = builder.buildConfiguration({
  *   transport: 'http',
  *   serverUrl: buildGleanMcpUrl('https://my-company-be.glean.com'),
@@ -247,22 +236,24 @@ export function normalizeGleanProductName(productName?: string): string {
  * Build a Glean-prefixed server name for MCP configurations.
  * Wraps the vendor-neutral buildMcpServerName with Glean-specific prefixing.
  *
+ * This function keeps the `'stdio' | 'http'` union on `transport` to remain
+ * compatible with {@link ServerNameBuilderCallback}, but the Glean registry
+ * itself no longer emits stdio invocations — stdio callers will still get a
+ * sensible `{product}_local` name if invoked directly.
+ *
  * Rules:
  * - If explicit serverName is provided and already has the product prefix, use it directly
  * - If explicit serverName is provided without prefix, add the product prefix
  * - If agents flag is set, return '{product}_agents'
- * - For stdio transport: '{product}_local'
  * - For http transport with URL: '{product}_{extracted-name}'
  * - Fallback: '{product}'
  *
  * @param options - Server name options
- * @returns Prefixed server name (e.g., 'glean_local', 'acme_analytics')
+ * @returns Prefixed server name (e.g., 'glean_default', 'acme_analytics')
  *
  * @example
  * ```typescript
- * buildGleanServerName({ transport: 'stdio' }); // 'glean_local'
  * buildGleanServerName({ transport: 'http', serverUrl: '.../mcp/analytics' }); // 'glean_analytics'
- * buildGleanServerName({ transport: 'stdio', productName: 'Acme' }); // 'acme_local'
  * buildGleanServerName({ agents: true }); // 'glean_agents'
  * buildGleanServerName({ serverName: 'custom' }); // 'glean_custom'
  * ```
@@ -276,9 +267,7 @@ export function buildGleanServerName(options: {
 }): string {
   const productPrefix = normalizeGleanProductName(options.productName);
 
-  // Handle explicit serverName
   if (options.serverName) {
-    // If it already has the correct prefix, use it directly
     if (
       options.serverName === productPrefix ||
       options.serverName.startsWith(`${productPrefix}_`)
@@ -288,18 +277,15 @@ export function buildGleanServerName(options: {
     return `${productPrefix}_${options.serverName}`;
   }
 
-  // Handle agents mode
   if (options.agents) {
     return `${productPrefix}_agents`;
   }
 
-  // Get base name from vendor-neutral function
   const baseName = buildMcpServerNameBase({
     transport: options.transport,
     serverUrl: options.serverUrl,
   });
 
-  // If baseName is 'default' and we have no specific info, just return the product prefix
   if (baseName === 'default' && !options.transport && !options.serverUrl) {
     return productPrefix;
   }

--- a/packages/mcp-config-glean/test/clients/claude-code.test.ts
+++ b/packages/mcp-config-glean/test/clients/claude-code.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Claude Code: native CLI client
@@ -15,59 +10,6 @@ describe('Client: claude-code', () => {
   const builder = registry.createBuilder('claude-code');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -112,30 +54,6 @@ describe('Client: claude-code', () => {
   });
 
   describe('buildCommand (native CLI)', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"claude mcp add glean_local --scope user --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token -- npx -y @gleanwork/local-mcp-server"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"claude mcp add glean_local --scope user --env GLEAN_INSTANCE=my-company -- npx -y @gleanwork/local-mcp-server"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/claude-desktop.test.ts
+++ b/packages/mcp-config-glean/test/clients/claude-desktop.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Claude Desktop: commandBuilder client (no native CLI)
@@ -15,59 +10,6 @@ describe('Client: claude-desktop', () => {
   const builder = registry.createBuilder('claude-desktop');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport (uses mcp-remote bridge)', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -121,30 +63,6 @@ describe('Client: claude-desktop', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client claude-desktop --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client claude-desktop --env GLEAN_INSTANCE=my-company"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/codex.test.ts
+++ b/packages/mcp-config-glean/test/clients/codex.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Codex: native CLI client
@@ -16,57 +11,6 @@ describe('Client: codex', () => {
   const builder = registry.createBuilder('codex');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcp_servers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcp_servers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -109,30 +53,6 @@ describe('Client: codex', () => {
   });
 
   describe('buildCommand (native CLI)', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"codex mcp add glean_local --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token -- npx -y @gleanwork/local-mcp-server"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"codex mcp add glean_local --env GLEAN_INSTANCE=my-company -- npx -y @gleanwork/local-mcp-server"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/cursor.test.ts
+++ b/packages/mcp-config-glean/test/clients/cursor.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Cursor: commandBuilder client (no native CLI)
@@ -15,59 +10,6 @@ describe('Client: cursor', () => {
   const builder = registry.createBuilder('cursor');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -112,30 +54,6 @@ describe('Client: cursor', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client cursor --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client cursor --env GLEAN_INSTANCE=my-company"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/gemini.test.ts
+++ b/packages/mcp-config-glean/test/clients/gemini.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Gemini: Native CLI client
@@ -16,57 +11,6 @@ describe('Client: gemini', () => {
   const builder = registry.createBuilder('gemini');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -109,30 +53,6 @@ describe('Client: gemini', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"gemini mcp add -e GLEAN_INSTANCE=my-company -e GLEAN_API_TOKEN=my-api-token glean_local npx -y @gleanwork/local-mcp-server"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"gemini mcp add -e GLEAN_INSTANCE=my-company glean_local npx -y @gleanwork/local-mcp-server"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/goose.test.ts
+++ b/packages/mcp-config-glean/test/clients/goose.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Goose: commandBuilder client (no native CLI)
@@ -15,71 +10,6 @@ describe('Client: goose', () => {
   const builder = registry.createBuilder('goose');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "extensions": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "bundled": null,
-                "cmd": "npx",
-                "description": null,
-                "enabled": true,
-                "env_keys": [],
-                "envs": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "name": "glean_local",
-                "timeout": 300,
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "extensions": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "bundled": null,
-                "cmd": "npx",
-                "description": null,
-                "enabled": true,
-                "env_keys": [],
-                "envs": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "name": "glean_local",
-                "timeout": 300,
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -141,30 +71,6 @@ describe('Client: goose', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client goose --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client goose --env GLEAN_INSTANCE=my-company"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/jetbrains.test.ts
+++ b/packages/mcp-config-glean/test/clients/jetbrains.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * JetBrains: IDE-managed client
@@ -16,59 +11,6 @@ describe('Client: jetbrains', () => {
   const builder = registry.createBuilder('jetbrains');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -113,26 +55,6 @@ describe('Client: jetbrains', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth returns null', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(`null`);
-      });
-
-      it('with OAuth returns null', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(`null`);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth returns null', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/junie.test.ts
+++ b/packages/mcp-config-glean/test/clients/junie.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Junie: commandBuilder client (no native CLI)
@@ -15,59 +10,6 @@ describe('Client: junie', () => {
   const builder = registry.createBuilder('junie');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport (native)', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -110,30 +52,6 @@ describe('Client: junie', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client junie --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client junie --env GLEAN_INSTANCE=my-company"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/vscode.test.ts
+++ b/packages/mcp-config-glean/test/clients/vscode.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * VS Code: native CLI client
@@ -15,59 +10,6 @@ describe('Client: vscode', () => {
   const builder = registry.createBuilder('vscode');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "servers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "servers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-                "type": "stdio",
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -112,30 +54,6 @@ describe('Client: vscode', () => {
   });
 
   describe('buildCommand (native CLI)', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"code --add-mcp '{"name":"glean_local","type":"stdio","command":"npx","args":["-y","@gleanwork/local-mcp-server"],"env":{"GLEAN_INSTANCE":"my-company","GLEAN_API_TOKEN":"my-api-token"}}'"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"code --add-mcp '{"name":"glean_local","type":"stdio","command":"npx","args":["-y","@gleanwork/local-mcp-server"],"env":{"GLEAN_INSTANCE":"my-company"}}'"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/clients/windsurf.test.ts
+++ b/packages/mcp-config-glean/test/clients/windsurf.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createGleanRegistry,
-  createGleanEnv,
-  createGleanHeaders,
-  buildGleanServerUrl,
-} from '../../src/index.js';
+import { createGleanRegistry, createGleanHeaders, buildGleanServerUrl } from '../../src/index.js';
 
 /**
  * Windsurf: commandBuilder client (no native CLI)
@@ -15,57 +10,6 @@ describe('Client: windsurf', () => {
   const builder = registry.createBuilder('windsurf');
 
   describe('buildConfiguration', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "my-api-token",
-                  "GLEAN_INSTANCE": "my-company",
-                },
-              },
-            },
-          }
-        `);
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const config = builder.buildConfiguration({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(config).toMatchInlineSnapshot(`
-          {
-            "mcpServers": {
-              "glean_local": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_INSTANCE": "my-company",
-                },
-              },
-            },
-          }
-        `);
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const config = builder.buildConfiguration({
@@ -108,30 +52,6 @@ describe('Client: windsurf', () => {
   });
 
   describe('buildCommand', () => {
-    describe('stdio transport', () => {
-      it('with token auth', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company', 'my-api-token'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client windsurf --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=my-api-token"`
-        );
-      });
-
-      it('with OAuth (instance only, no token)', () => {
-        const command = builder.buildCommand({
-          transport: 'stdio',
-          env: createGleanEnv('my-company'),
-        });
-
-        expect(command).toMatchInlineSnapshot(
-          `"npx -y @gleanwork/configure-mcp-server local --client windsurf --env GLEAN_INSTANCE=my-company"`
-        );
-      });
-    });
-
     describe('http transport', () => {
       it('with token auth', () => {
         const command = builder.buildCommand({

--- a/packages/mcp-config-glean/test/index.test.ts
+++ b/packages/mcp-config-glean/test/index.test.ts
@@ -18,8 +18,8 @@ import {
 
 describe('@gleanwork/mcp-config', () => {
   describe('GLEAN_REGISTRY_OPTIONS', () => {
-    it('has correct serverPackage', () => {
-      expect(GLEAN_REGISTRY_OPTIONS.serverPackage).toBe('@gleanwork/local-mcp-server');
+    it('does not define a serverPackage (remote-only registry)', () => {
+      expect(GLEAN_REGISTRY_OPTIONS.serverPackage).toBeUndefined();
     });
 
     it('has commandBuilder for http transport', () => {
@@ -46,26 +46,19 @@ describe('@gleanwork/mcp-config', () => {
       );
     });
 
-    it('has commandBuilder for stdio transport', () => {
-      expect(GLEAN_REGISTRY_OPTIONS.commandBuilder?.stdio).toBeDefined();
-
-      const command = GLEAN_REGISTRY_OPTIONS.commandBuilder?.stdio?.('cursor', {
-        transport: 'stdio',
-        env: { GLEAN_INSTANCE: 'my-company', GLEAN_API_TOKEN: 'token' },
+    it('commandBuilder http pins the CLI version when cliVersion is provided', () => {
+      const command = GLEAN_REGISTRY_OPTIONS.commandBuilder?.http?.('cursor', {
+        transport: 'http',
+        serverUrl: 'https://example.com/mcp/default',
+        cliVersion: '3.1.0',
       });
       expect(command).toBe(
-        'npx -y @gleanwork/configure-mcp-server local --client cursor --env GLEAN_INSTANCE=my-company --env GLEAN_API_TOKEN=token'
+        'npx -y @gleanwork/configure-mcp-server@3.1.0 remote --url https://example.com/mcp/default --client cursor'
       );
     });
 
-    it('commandBuilder stdio works with GLEAN_SERVER_URL env', () => {
-      const command = GLEAN_REGISTRY_OPTIONS.commandBuilder?.stdio?.('cursor', {
-        transport: 'stdio',
-        env: { GLEAN_SERVER_URL: 'https://my-company-be.glean.com', GLEAN_API_TOKEN: 'token' },
-      });
-      expect(command).toBe(
-        'npx -y @gleanwork/configure-mcp-server local --client cursor --env GLEAN_SERVER_URL=https://my-company-be.glean.com --env GLEAN_API_TOKEN=token'
-      );
+    it('does not define a stdio commandBuilder', () => {
+      expect(GLEAN_REGISTRY_OPTIONS.commandBuilder?.stdio).toBeUndefined();
     });
 
     it('commandBuilder http returns null when no serverUrl', () => {
@@ -76,9 +69,6 @@ describe('@gleanwork/mcp-config', () => {
     });
 
     it('serverNameBuilder delegates to buildGleanServerName', () => {
-      expect(GLEAN_REGISTRY_OPTIONS.serverNameBuilder?.({ transport: 'stdio' })).toBe(
-        'glean_local'
-      );
       expect(GLEAN_REGISTRY_OPTIONS.serverNameBuilder?.({ transport: 'http' })).toBe(
         'glean_default'
       );
@@ -199,6 +189,11 @@ describe('@gleanwork/mcp-config', () => {
       const registry = createGleanRegistry();
       const builder = registry.createBuilder('cursor');
       expect(builder).toBeDefined();
+    });
+
+    it('reports no local server (remote-only registry)', () => {
+      const registry = createGleanRegistry();
+      expect(registry.hasLocalServer()).toBe(false);
     });
   });
 

--- a/packages/mcp-config-schema/src/registry.ts
+++ b/packages/mcp-config-schema/src/registry.ts
@@ -252,6 +252,20 @@ export class MCPConfigRegistry {
   }
 
   /**
+   * Determines if this registry advertises a local (stdio) server package.
+   *
+   * A registry is "local-capable" when it defines {@link RegistryOptions.serverPackage},
+   * which identifies the npm package the stdio builder spawns. When absent, stdio
+   * config generation will throw. Consumers (e.g., installer CLIs) can use this to
+   * emit a friendly message before attempting stdio installation.
+   *
+   * @returns true if a serverPackage is configured for this registry
+   */
+  hasLocalServer(): boolean {
+    return typeof this.options.serverPackage === 'string' && this.options.serverPackage.length > 0;
+  }
+
+  /**
    * Create a configuration builder for a specific client.
    *
    * The returned builder is typed based on the client ID:

--- a/packages/mcp-config-schema/src/schemas.ts
+++ b/packages/mcp-config-schema/src/schemas.ts
@@ -99,6 +99,7 @@ export const MCPConnectionOptionsSchema = z
     env: z.record(z.string(), z.string()).optional(), // Environment variables for stdio server
     // Common options
     serverName: z.string().optional(),
+    cliVersion: z.string().optional(), // Version tag to pin for registry-provided CLI install commands (e.g., '3.1.0')
   })
   .merge(BuildOptionsSchema);
 


### PR DESCRIPTION
## Summary

- Removes the local/stdio code path from `@gleanwork/mcp-config-glean` (breaking).
- Adds optional `cliVersion` parameter on `MCPConnectionOptions` and a `registry.hasLocalServer()` accessor in `@gleanwork/mcp-config-schema` (minor, additive).
- Closes the gap between the stated position ("not recommended for production") and shipped behavior — after this ships, the Glean registry is structurally incapable of emitting `configure-mcp-server local` snippets.

## Target versions (release-it will set at publish time)

- `@gleanwork/mcp-config-schema` → minor bump (`4.3.0` → `4.4.0` recommended).
- `@gleanwork/mcp-config-glean` → major bump (`4.3.0` → `5.0.0` recommended).

This PR intentionally does **not** modify self-versions in `package.json` or the lockfile — those are release-it's domain.

## Notable details

- `buildGleanServerName` keeps its `'stdio' | 'http'` transport union so it remains a valid `ServerNameBuilderCallback`. The Glean registry just never invokes the stdio branch anymore.
- README examples and 15 stdio-exercise test cases deleted across client tests; http-transport coverage retained.
- Net diff: ~-826 lines.

## Downstream

- `@gleanwork/configure-mcp-server` — detects the missing local server via `registry.hasLocalServer()` and emits a friendly error (see its own PR).
- In-app MCP Configurator — bumps `mcp-config-glean` dep and pins `configure-mcp-server` via `cliVersion` (tracked separately, blocked on this publish).

## Test plan

- [x] `npm run build` passes both packages
- [x] `npm run test:all` — 285/285 tests pass
- [x] lint + typecheck clean
- [x] Scratch repro: `createGleanRegistry().hasLocalServer()` returns `false`
- [x] Scratch repro: `builder.buildCommand({ transport: 'http', ..., cliVersion: '3.1.0' })` emits `npx -y @gleanwork/configure-mcp-server@3.1.0 remote ...`