### PR TITLE
feat: add Antigravity CLI MCP client configuration

### DIFF
--- a/packages/mcp-config-schema/CLIENTS.md
+++ b/packages/mcp-config-schema/CLIENTS.md
@@ -7,6 +7,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
 | Client | Configuration | Connection Type | Auth Support | Requires mcp-remote? | Platforms |
 |---|---|---|---|---|---|
 | **Antigravity** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
+| **Antigravity CLI** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
 | **ChatGPT** | Managed | HTTP only | Token, OAuth DCR | No | Web-based |
 | **Claude Code** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
 | **Claude for Desktop** | User-configurable | stdio only | None | Yes (for HTTP) | macOS, Windows, Linux |
@@ -97,6 +98,99 @@ This document provides a comprehensive overview of all supported MCP clients, th
 <summary><strong>stdio Configuration</strong></summary>
 
 ```json snippet=examples/configs/stdio/antigravity.json
+{
+  "mcpServers": {
+    "example": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@example/mcp-server"
+      ],
+      "env": {
+        "EXAMPLE_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+---
+
+### Antigravity CLI
+
+- **Configuration**: User-configurable
+- **Connection Type**: Native HTTP support
+- **Documentation**: [Link](https://antigravity.google/docs/cli-overview)
+- **Supported Platforms**: macOS, Linux, Windows
+- **Auth Support**: Token, OAuth DCR
+- **OAuth Redirect**: `http://localhost:*/oauth/callback`
+- **Configuration Paths**:
+  - **macOS/Linux**: `$HOME/.gemini/config/mcp_config.json`
+  - **Windows**: `%USERPROFILE%\.gemini\config\mcp_config.json`
+
+<details>
+<summary><strong>Internal Configuration Schema</strong></summary>
+
+```json snippet=configs/antigravity-cli.json
+{
+  "id": "antigravity-cli",
+  "name": "antigravity-cli",
+  "displayName": "Antigravity CLI",
+  "description": "Antigravity CLI with native HTTP and stdio support",
+  "userConfigurable": true,
+  "documentationUrl": "https://antigravity.google/docs/cli-overview",
+  "transports": ["stdio", "http"],
+  "supportedPlatforms": ["darwin", "linux", "win32"],
+  "configFormat": "json",
+  "configPath": {
+    "darwin": "$HOME/.gemini/config/mcp_config.json",
+    "linux": "$HOME/.gemini/config/mcp_config.json",
+    "win32": "%USERPROFILE%\\.gemini\\config\\mcp_config.json"
+  },
+  "configStructure": {
+    "serversPropertyName": "mcpServers",
+    "httpPropertyMapping": {
+      "urlProperty": "serverUrl",
+      "headersProperty": "headers"
+    },
+    "stdioPropertyMapping": {
+      "commandProperty": "command",
+      "argsProperty": "args",
+      "envProperty": "env"
+    }
+  },
+  "supportedAuth": ["token", "oauth:dcr"],
+  "oauth": {
+    "dcr": {
+      "redirect_uri_patterns": ["http://localhost:*/oauth/callback"]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>HTTP Configuration</strong></summary>
+
+```json snippet=examples/configs/http/antigravity-cli.json
+{
+  "mcpServers": {
+    "example": {
+      "serverUrl": "https://api.example.com/mcp"
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>stdio Configuration</strong></summary>
+
+```json snippet=examples/configs/stdio/antigravity-cli.json
 {
   "mcpServers": {
     "example": {
@@ -686,7 +780,7 @@ EXAMPLE_API_KEY = "your-api-key"
 
 - **Configuration**: User-configurable
 - **Connection Type**: Native HTTP support
-- **Documentation**: [Link](https://geminicli.com/docs/tools/mcp-server/)
+- **Documentation**: [Link](https://github.com/google-gemini/gemini-cli)
 - **Supported Platforms**: macOS, Linux, Windows
 - **Auth Support**: Token, OAuth DCR
 - **OAuth Redirect**: `http://localhost:*/oauth/callback`
@@ -704,7 +798,7 @@ EXAMPLE_API_KEY = "your-api-key"
   "displayName": "Gemini CLI",
   "description": "Gemini CLI with native HTTP and stdio support",
   "userConfigurable": true,
-  "documentationUrl": "https://geminicli.com/docs/tools/mcp-server/",
+  "documentationUrl": "https://github.com/google-gemini/gemini-cli",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],
   "configFormat": "json",
@@ -1366,6 +1460,7 @@ extensions:
 ### Native HTTP Clients
 Clients that can connect directly to HTTP MCP servers without additional tooling:
 - Antigravity
+- Antigravity CLI
 - Claude Code
 - Codex
 - Cursor

--- a/packages/mcp-config-schema/configs/antigravity-cli.json
+++ b/packages/mcp-config-schema/configs/antigravity-cli.json
@@ -1,22 +1,22 @@
 {
-  "id": "gemini",
-  "name": "gemini",
-  "displayName": "Gemini CLI",
-  "description": "Gemini CLI with native HTTP and stdio support",
+  "id": "antigravity-cli",
+  "name": "antigravity-cli",
+  "displayName": "Antigravity CLI",
+  "description": "Antigravity CLI with native HTTP and stdio support",
   "userConfigurable": true,
-  "documentationUrl": "https://github.com/google-gemini/gemini-cli",
+  "documentationUrl": "https://antigravity.google/docs/cli-overview",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],
   "configFormat": "json",
   "configPath": {
-    "darwin": "$HOME/.gemini/settings.json",
-    "linux": "$HOME/.gemini/settings.json",
-    "win32": "%USERPROFILE%\\.gemini\\settings.json"
+    "darwin": "$HOME/.gemini/config/mcp_config.json",
+    "linux": "$HOME/.gemini/config/mcp_config.json",
+    "win32": "%USERPROFILE%\\.gemini\\config\\mcp_config.json"
   },
   "configStructure": {
     "serversPropertyName": "mcpServers",
     "httpPropertyMapping": {
-      "urlProperty": "httpUrl",
+      "urlProperty": "serverUrl",
       "headersProperty": "headers"
     },
     "stdioPropertyMapping": {

--- a/packages/mcp-config-schema/examples/configs/http/antigravity-cli.json
+++ b/packages/mcp-config-schema/examples/configs/http/antigravity-cli.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "example": {
+      "serverUrl": "https://api.example.com/mcp"
+    }
+  }
+}

--- a/packages/mcp-config-schema/examples/configs/stdio/antigravity-cli.json
+++ b/packages/mcp-config-schema/examples/configs/stdio/antigravity-cli.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "example": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@example/mcp-server"
+      ],
+      "env": {
+        "EXAMPLE_API_KEY": "your-api-key"
+      }
+    }
+  }
+}

--- a/packages/mcp-config-schema/src/constants.ts
+++ b/packages/mcp-config-schema/src/constants.ts
@@ -3,6 +3,7 @@
  */
 export const CLIENT = {
   ANTIGRAVITY: 'antigravity',
+  ANTIGRAVITY_CLI: 'antigravity-cli',
   CLAUDE_CODE: 'claude-code',
   CLAUDE_DESKTOP: 'claude-desktop',
   CLAUDE_TEAMS_ENTERPRISE: 'claude-teams-enterprise',
@@ -23,6 +24,7 @@ export const CLIENT = {
  */
 export const CLIENT_DISPLAY_NAME = {
   ANTIGRAVITY: 'Antigravity',
+  ANTIGRAVITY_CLI: 'Antigravity CLI',
   CLAUDE_CODE: 'Claude Code',
   CLAUDE_DESKTOP: 'Claude for Desktop',
   CLAUDE_TEAMS_ENTERPRISE: 'Claude for Teams/Enterprise',
@@ -54,6 +56,7 @@ export type ClientDisplayName = (typeof CLIENT_DISPLAY_NAME)[keyof typeof CLIENT
 export function getDisplayName(clientId: ClientIdConstant): ClientDisplayName {
   const mapping: Record<ClientIdConstant, ClientDisplayName> = {
     [CLIENT.ANTIGRAVITY]: CLIENT_DISPLAY_NAME.ANTIGRAVITY,
+    [CLIENT.ANTIGRAVITY_CLI]: CLIENT_DISPLAY_NAME.ANTIGRAVITY_CLI,
     [CLIENT.CLAUDE_CODE]: CLIENT_DISPLAY_NAME.CLAUDE_CODE,
     [CLIENT.CLAUDE_DESKTOP]: CLIENT_DISPLAY_NAME.CLAUDE_DESKTOP,
     [CLIENT.CLAUDE_TEAMS_ENTERPRISE]: CLIENT_DISPLAY_NAME.CLAUDE_TEAMS_ENTERPRISE,

--- a/packages/mcp-config-schema/src/registry.ts
+++ b/packages/mcp-config-schema/src/registry.ts
@@ -34,8 +34,10 @@ import jetbrainsConfig from '../configs/jetbrains.json';
 import geminiConfig from '../configs/gemini.json';
 import opencodeConfig from '../configs/opencode.json';
 import antigravityConfig from '../configs/antigravity.json';
+import antigravityCliConfig from '../configs/antigravity-cli.json';
 const allConfigs = [
   antigravityConfig,
+  antigravityCliConfig,
   chatgptConfig,
   claudeCodeConfig,
   claudeDesktopConfig,

--- a/packages/mcp-config-schema/src/schemas.ts
+++ b/packages/mcp-config-schema/src/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 export const PlatformSchema = z.enum(['darwin', 'linux', 'win32']);
 export const ClientIdSchema = z.enum([
   'antigravity',
+  'antigravity-cli',
   'claude-code',
   'vscode',
   'claude-desktop',
@@ -292,6 +293,7 @@ export function validateGeneratedConfig(
       schema = GeminiConfigSchema;
       break;
     case 'antigravity':
+    case 'antigravity-cli':
     case 'claude-code':
     case 'claude-desktop':
     case 'cursor':

--- a/packages/mcp-config-schema/test/builder.test.ts
+++ b/packages/mcp-config-schema/test/builder.test.ts
@@ -679,6 +679,79 @@ describe('ConfigBuilder', () => {
       `);
     });
 
+    it('should generate correct HTTP config for Antigravity CLI', () => {
+      const builder = registry.createBuilder(CLIENT.ANTIGRAVITY_CLI);
+      const result = builder.buildConfiguration(remoteConfig);
+
+      const validation = validateGeneratedConfig(result, 'antigravity-cli');
+      expect(validation.success).toBe(true);
+
+      // Antigravity CLI uses serverUrl (not url) and no type property
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "mcpServers": {
+            "glean": {
+              "serverUrl": "https://glean-dev-be.glean.com/mcp/default",
+            },
+          },
+        }
+      `);
+    });
+
+    it('should add headers to Antigravity CLI HTTP config', () => {
+      const builder = registry.createBuilder(CLIENT.ANTIGRAVITY_CLI);
+      const result = builder.buildConfiguration({
+        transport: 'http',
+        serverUrl: 'https://glean-dev-be.glean.com/mcp/default',
+        headers: { Authorization: 'Bearer test-token-123' },
+      });
+
+      const validation = validateGeneratedConfig(result, 'antigravity-cli');
+      expect(validation.success).toBe(true);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "mcpServers": {
+            "default": {
+              "headers": {
+                "Authorization": "Bearer test-token-123",
+              },
+              "serverUrl": "https://glean-dev-be.glean.com/mcp/default",
+            },
+          },
+        }
+      `);
+    });
+
+    it('should generate correct stdio config for Antigravity CLI', () => {
+      const builder = registry.createBuilder(CLIENT.ANTIGRAVITY_CLI);
+      const result = builder.buildConfiguration({
+        transport: 'stdio',
+        env: createGleanEnv('test-instance', 'test-token'),
+      });
+
+      const validation = validateGeneratedConfig(result, 'antigravity-cli');
+      expect(validation.success).toBe(true);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "mcpServers": {
+            "local": {
+              "args": [
+                "-y",
+                "@gleanwork/local-mcp-server",
+              ],
+              "command": "npx",
+              "env": {
+                "GLEAN_API_TOKEN": "test-token",
+                "GLEAN_INSTANCE": "test-instance",
+              },
+            },
+          },
+        }
+      `);
+    });
+
     it('should generate correct HTTP config for Gemini CLI', () => {
       const builder = registry.createBuilder(CLIENT.GEMINI);
       const result = builder.buildConfiguration(remoteConfig);


### PR DESCRIPTION
## Summary

Adds support for **Antigravity CLI**, the new terminal-first agent surface from Google, as a distinct MCP client.

Antigravity CLI is a separate product from both Gemini CLI and the Antigravity IDE, and uses its own MCP configuration target:

- Config path: `~/.gemini/config/mcp_config.json` (global)
- HTTP server URL key: `serverUrl`
- Transports: stdio + HTTP

This change is purely additive. The existing `gemini` (Gemini CLI) and `antigravity` (Antigravity IDE) clients are unchanged, since all three are distinct configuration targets.

## Changes

- New `configs/antigravity-cli.json`, registered in the registry, constants, and client-id schema
- Tests covering HTTP, HTTP-with-headers, and stdio config generation
- Regenerated `CLIENTS.md` and `examples/` via `generate:docs`
- Update Gemini CLI `documentationUrl` to the official GitHub repository (github.com/google-gemini/gemini-cli)

## Verification

`npm run test:all` — lint, typecheck, and 288 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
