### PR TITLE
refactor: generate client constants from configs (single source of truth)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,11 @@ Each MCP client (Cursor, VS Code, Claude Desktop, etc.) has a JSON config in `pa
 
 ## Adding a New Client
 
-1. Create config JSON in `packages/mcp-config-schema/configs/`
-2. Add import to `packages/mcp-config-schema/src/registry.ts`
-3. Add to `allConfigs` array
-4. If custom builder logic needed, create class in `src/builders/` extending `BaseConfigBuilder`
-5. Update `packages/mcp-config-schema/CLIENTS.md` to include the new client
+1. Create config JSON in `packages/mcp-config-schema/configs/`. **The filename must equal the `id`** (e.g. `cursor.json` → `"id": "cursor"`).
+2. Run `npm run generate -w @gleanwork/mcp-config-schema`. This regenerates `src/clients.generated.ts` (the `CLIENT` constants, `CLIENT_DISPLAY_NAME`, the `ClientId` enum, and the registry's config list) plus `CLIENTS.md` and `examples/`.
+3. If custom builder logic is needed, create a class in `src/builders/` extending `BaseConfigBuilder` and register it in `registry.ts`.
+
+> The client constants, the Zod `ClientIdSchema` enum, and the registry list are **generated from `configs/*.json`** — never hand-edit them. A guard test (`test/clients-generated.test.ts`) fails if the generated file is stale.
 
 ## Release
 

--- a/packages/mcp-config-schema/CLAUDE.md
+++ b/packages/mcp-config-schema/CLAUDE.md
@@ -134,10 +134,11 @@ Configuration files are written to client-specific locations:
 
 ### Adding a New Client
 
-1. Create config JSON in `/configs/`
-2. Add import to `src/registry.ts:3-10`
-3. Add to `allConfigs` array (src/registry.ts:11)
-4. Update TypeScript types if needed
+1. Create config JSON in `/configs/`. **The filename must equal the `id`.**
+2. Run `npm run generate` (regenerates `src/clients.generated.ts`, `examples/`, and `CLIENTS.md`).
+3. If custom builder logic is needed, add a class in `src/builders/` and register it in `registry.ts`.
+
+`CLIENT`, `CLIENT_DISPLAY_NAME`, the `ClientId` enum (`ClientIdSchema`), and the registry's `allClientConfigs` list are **generated from `configs/*.json`** by `scripts/generate-clients.ts` — do not hand-edit `src/clients.generated.ts`. `test/clients-generated.test.ts` fails if it drifts.
 
 ### Testing Configurations
 

--- a/packages/mcp-config-schema/CLIENTS.md
+++ b/packages/mcp-config-schema/CLIENTS.md
@@ -20,7 +20,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
 | **JetBrains AI Assistant** | User-configurable | HTTP native | Token | No | macOS, Linux, Windows |
 | **Junie (JetBrains)** | User-configurable | HTTP native | Token | No | macOS, Linux, Windows |
 | **OpenCode** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
-| **Visual Studio Code** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
+| **VS Code** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
 | **Windsurf** | User-configurable | HTTP native | Token, OAuth DCR | No | macOS, Linux, Windows |
 
 ## Detailed Client Information
@@ -1245,7 +1245,7 @@ extensions:
 
 ---
 
-### Visual Studio Code
+### VS Code
 
 - **Configuration**: User-configurable
 - **Connection Type**: Native HTTP support
@@ -1266,7 +1266,7 @@ extensions:
 {
   "id": "vscode",
   "name": "vscode",
-  "displayName": "Visual Studio Code",
+  "displayName": "VS Code",
   "description": "VS Code with native HTTP support",
   "userConfigurable": true,
   "documentationUrl": "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",
@@ -1470,7 +1470,7 @@ Clients that can connect directly to HTTP MCP servers without additional tooling
 - JetBrains AI Assistant
 - Junie (JetBrains)
 - OpenCode
-- Visual Studio Code
+- VS Code
 - Windsurf
 
 ### stdio-only Clients
@@ -1508,7 +1508,7 @@ Used by: Goose
 
 Some clients support one-click installation via custom protocols:
 - **Cursor**: `cursor://`
-- **Visual Studio Code**: `vscode:`
+- **VS Code**: `vscode:`
 
 ## Additional Resources
 

--- a/packages/mcp-config-schema/configs/vscode.json
+++ b/packages/mcp-config-schema/configs/vscode.json
@@ -1,7 +1,7 @@
 {
   "id": "vscode",
   "name": "vscode",
-  "displayName": "Visual Studio Code",
+  "displayName": "VS Code",
   "description": "VS Code with native HTTP support",
   "userConfigurable": true,
   "documentationUrl": "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",

--- a/packages/mcp-config-schema/package.json
+++ b/packages/mcp-config-schema/package.json
@@ -46,9 +46,11 @@
     "test:all": "npm run typecheck && npm run test",
     "lint:clients": "npx markdown-code check CLIENTS.md",
     "typecheck": "tsc --noEmit",
+    "generate:clients": "tsx scripts/generate-clients.ts && npx prettier --write src/clients.generated.ts",
     "generate:examples": "tsx scripts/generate-examples.ts",
     "generate:clients-md": "tsx scripts/generate-clients-md.ts",
     "generate:docs": "npm run generate:examples && npm run generate:clients-md && npx markdown-code sync CLIENTS.md",
+    "generate": "npm run generate:clients && npm run generate:docs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/mcp-config-schema/scripts/generate-clients.ts
+++ b/packages/mcp-config-schema/scripts/generate-clients.ts
@@ -1,0 +1,115 @@
+/**
+ * Generate src/clients.generated.ts from the configs/*.json files.
+ *
+ * The config files are the single source of truth for client identity. This
+ * script derives the constants, the client-id tuple (for the Zod enum), and the
+ * config import list so those never have to be hand-maintained in lockstep.
+ *
+ * Run via `npm run generate:clients`. The output is committed and guarded by a
+ * staleness test (test/clients-generated.test.ts).
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const configsDir = join(here, '..', 'configs');
+const outPath = join(here, '..', 'src', 'clients.generated.ts');
+
+interface ClientMeta {
+  id: string;
+  displayName: string;
+  /** SCREAMING_SNAKE_CASE constant key, e.g. 'claude-code' -> 'CLAUDE_CODE' */
+  key: string;
+  /** camelCase import binding, e.g. 'claude-code' -> 'claudeCodeConfig' */
+  binding: string;
+}
+
+function toKey(id: string): string {
+  return id.toUpperCase().replace(/-/g, '_');
+}
+
+function toBinding(id: string): string {
+  return id.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase()) + 'Config';
+}
+
+export function readClients(): ClientMeta[] {
+  const files = readdirSync(configsDir)
+    .filter((f) => f.endsWith('.json'))
+    .sort();
+
+  return files.map((file) => {
+    const base = file.replace(/\.json$/, '');
+    const raw = JSON.parse(readFileSync(join(configsDir, file), 'utf8')) as {
+      id?: string;
+      displayName?: string;
+    };
+
+    if (raw.id !== base) {
+      throw new Error(
+        `Config filename must match its id: ${file} declares id "${raw.id ?? '(missing)'}". ` +
+          `Rename the file to "${raw.id}.json" or fix the id.`
+      );
+    }
+    if (!raw.displayName) {
+      throw new Error(`Config ${file} is missing a displayName.`);
+    }
+
+    return { id: base, displayName: raw.displayName, key: toKey(base), binding: toBinding(base) };
+  });
+}
+
+export function generateClientsSource(clients: ClientMeta[] = readClients()): string {
+  const imports = clients
+    .map((c) => `import ${c.binding} from '../configs/${c.id}.json';`)
+    .join('\n');
+
+  const clientEntries = clients.map((c) => `  ${c.key}: '${c.id}',`).join('\n');
+  const displayNameEntries = clients
+    .map((c) => `  ${c.key}: ${JSON.stringify(c.displayName)},`)
+    .join('\n');
+  const displayByIdEntries = clients
+    .map((c) => `  '${c.id}': ${JSON.stringify(c.displayName)},`)
+    .join('\n');
+  const idEntries = clients.map((c) => `  '${c.id}',`).join('\n');
+  const configEntries = clients.map((c) => `  ${c.binding},`).join('\n');
+
+  return `/**
+ * AUTO-GENERATED FILE — DO NOT EDIT BY HAND.
+ *
+ * Generated from configs/*.json by scripts/generate-clients.ts.
+ * Run \`npm run generate:clients\` to regenerate after adding or editing a client.
+ */
+${imports}
+
+/** Canonical client IDs, keyed by constant name. */
+export const CLIENT = {
+${clientEntries}
+} as const;
+
+/** Display names, keyed by the same constant name as {@link CLIENT}. */
+export const CLIENT_DISPLAY_NAME = {
+${displayNameEntries}
+} as const;
+
+/** Display names keyed by client id (used by getDisplayName). */
+export const DISPLAY_NAME_BY_ID = {
+${displayByIdEntries}
+} as const;
+
+/** All client ids as a literal tuple — the source for ClientIdSchema. */
+export const CLIENT_IDS = [
+${idEntries}
+] as const;
+
+/** Every client config, in id order. */
+export const allClientConfigs = [
+${configEntries}
+];
+`;
+}
+
+const source = generateClientsSource();
+writeFileSync(outPath, source);
+
+console.log(`✨ Generated src/clients.generated.ts (${readClients().length} clients)`);

--- a/packages/mcp-config-schema/src/clients.generated.ts
+++ b/packages/mcp-config-schema/src/clients.generated.ts
@@ -1,0 +1,122 @@
+/**
+ * AUTO-GENERATED FILE — DO NOT EDIT BY HAND.
+ *
+ * Generated from configs/*.json by scripts/generate-clients.ts.
+ * Run `npm run generate:clients` to regenerate after adding or editing a client.
+ */
+import antigravityCliConfig from '../configs/antigravity-cli.json';
+import antigravityConfig from '../configs/antigravity.json';
+import chatgptConfig from '../configs/chatgpt.json';
+import claudeCodeConfig from '../configs/claude-code.json';
+import claudeDesktopConfig from '../configs/claude-desktop.json';
+import claudeTeamsEnterpriseConfig from '../configs/claude-teams-enterprise.json';
+import codexConfig from '../configs/codex.json';
+import cursorAgentConfig from '../configs/cursor-agent.json';
+import cursorConfig from '../configs/cursor.json';
+import geminiConfig from '../configs/gemini.json';
+import gooseConfig from '../configs/goose.json';
+import jetbrainsConfig from '../configs/jetbrains.json';
+import junieConfig from '../configs/junie.json';
+import opencodeConfig from '../configs/opencode.json';
+import vscodeConfig from '../configs/vscode.json';
+import windsurfConfig from '../configs/windsurf.json';
+
+/** Canonical client IDs, keyed by constant name. */
+export const CLIENT = {
+  ANTIGRAVITY_CLI: 'antigravity-cli',
+  ANTIGRAVITY: 'antigravity',
+  CHATGPT: 'chatgpt',
+  CLAUDE_CODE: 'claude-code',
+  CLAUDE_DESKTOP: 'claude-desktop',
+  CLAUDE_TEAMS_ENTERPRISE: 'claude-teams-enterprise',
+  CODEX: 'codex',
+  CURSOR_AGENT: 'cursor-agent',
+  CURSOR: 'cursor',
+  GEMINI: 'gemini',
+  GOOSE: 'goose',
+  JETBRAINS: 'jetbrains',
+  JUNIE: 'junie',
+  OPENCODE: 'opencode',
+  VSCODE: 'vscode',
+  WINDSURF: 'windsurf',
+} as const;
+
+/** Display names, keyed by the same constant name as {@link CLIENT}. */
+export const CLIENT_DISPLAY_NAME = {
+  ANTIGRAVITY_CLI: 'Antigravity CLI',
+  ANTIGRAVITY: 'Antigravity',
+  CHATGPT: 'ChatGPT',
+  CLAUDE_CODE: 'Claude Code',
+  CLAUDE_DESKTOP: 'Claude for Desktop',
+  CLAUDE_TEAMS_ENTERPRISE: 'Claude for Teams/Enterprise',
+  CODEX: 'Codex',
+  CURSOR_AGENT: 'Cursor Agent',
+  CURSOR: 'Cursor',
+  GEMINI: 'Gemini CLI',
+  GOOSE: 'Goose',
+  JETBRAINS: 'JetBrains AI Assistant',
+  JUNIE: 'Junie (JetBrains)',
+  OPENCODE: 'OpenCode',
+  VSCODE: 'VS Code',
+  WINDSURF: 'Windsurf',
+} as const;
+
+/** Display names keyed by client id (used by getDisplayName). */
+export const DISPLAY_NAME_BY_ID = {
+  'antigravity-cli': 'Antigravity CLI',
+  antigravity: 'Antigravity',
+  chatgpt: 'ChatGPT',
+  'claude-code': 'Claude Code',
+  'claude-desktop': 'Claude for Desktop',
+  'claude-teams-enterprise': 'Claude for Teams/Enterprise',
+  codex: 'Codex',
+  'cursor-agent': 'Cursor Agent',
+  cursor: 'Cursor',
+  gemini: 'Gemini CLI',
+  goose: 'Goose',
+  jetbrains: 'JetBrains AI Assistant',
+  junie: 'Junie (JetBrains)',
+  opencode: 'OpenCode',
+  vscode: 'VS Code',
+  windsurf: 'Windsurf',
+} as const;
+
+/** All client ids as a literal tuple — the source for ClientIdSchema. */
+export const CLIENT_IDS = [
+  'antigravity-cli',
+  'antigravity',
+  'chatgpt',
+  'claude-code',
+  'claude-desktop',
+  'claude-teams-enterprise',
+  'codex',
+  'cursor-agent',
+  'cursor',
+  'gemini',
+  'goose',
+  'jetbrains',
+  'junie',
+  'opencode',
+  'vscode',
+  'windsurf',
+] as const;
+
+/** Every client config, in id order. */
+export const allClientConfigs = [
+  antigravityCliConfig,
+  antigravityConfig,
+  chatgptConfig,
+  claudeCodeConfig,
+  claudeDesktopConfig,
+  claudeTeamsEnterpriseConfig,
+  codexConfig,
+  cursorAgentConfig,
+  cursorConfig,
+  geminiConfig,
+  gooseConfig,
+  jetbrainsConfig,
+  junieConfig,
+  opencodeConfig,
+  vscodeConfig,
+  windsurfConfig,
+];

--- a/packages/mcp-config-schema/src/constants.ts
+++ b/packages/mcp-config-schema/src/constants.ts
@@ -1,44 +1,14 @@
 /**
- * Canonical client IDs for MCP clients
+ * Client id and display-name constants.
+ *
+ * The values are generated from configs/*.json by scripts/generate-clients.ts;
+ * this module layers the public types and the getDisplayName helper on top of
+ * the generated data. To add or rename a client, edit the config file and run
+ * `npm run generate:clients`.
  */
-export const CLIENT = {
-  ANTIGRAVITY: 'antigravity',
-  ANTIGRAVITY_CLI: 'antigravity-cli',
-  CLAUDE_CODE: 'claude-code',
-  CLAUDE_DESKTOP: 'claude-desktop',
-  CLAUDE_TEAMS_ENTERPRISE: 'claude-teams-enterprise',
-  CODEX: 'codex',
-  CURSOR: 'cursor',
-  VSCODE: 'vscode',
-  WINDSURF: 'windsurf',
-  GOOSE: 'goose',
-  CHATGPT: 'chatgpt',
-  JUNIE: 'junie',
-  JETBRAINS: 'jetbrains',
-  GEMINI: 'gemini',
-  OPENCODE: 'opencode',
-} as const;
+import { CLIENT, CLIENT_DISPLAY_NAME, DISPLAY_NAME_BY_ID } from './clients.generated.js';
 
-/**
- * Display names for MCP clients
- */
-export const CLIENT_DISPLAY_NAME = {
-  ANTIGRAVITY: 'Antigravity',
-  ANTIGRAVITY_CLI: 'Antigravity CLI',
-  CLAUDE_CODE: 'Claude Code',
-  CLAUDE_DESKTOP: 'Claude for Desktop',
-  CLAUDE_TEAMS_ENTERPRISE: 'Claude for Teams/Enterprise',
-  CODEX: 'Codex',
-  CURSOR: 'Cursor',
-  VSCODE: 'VS Code',
-  WINDSURF: 'Windsurf',
-  GOOSE: 'Goose',
-  CHATGPT: 'ChatGPT',
-  JUNIE: 'Junie (JetBrains)',
-  JETBRAINS: 'JetBrains AI Assistant',
-  GEMINI: 'Gemini CLI',
-  OPENCODE: 'OpenCode',
-} as const;
+export { CLIENT, CLIENT_DISPLAY_NAME };
 
 /**
  * Type-safe client ID type derived from the constants
@@ -54,22 +24,5 @@ export type ClientDisplayName = (typeof CLIENT_DISPLAY_NAME)[keyof typeof CLIENT
  * Helper to get display name from client ID
  */
 export function getDisplayName(clientId: ClientIdConstant): ClientDisplayName {
-  const mapping: Record<ClientIdConstant, ClientDisplayName> = {
-    [CLIENT.ANTIGRAVITY]: CLIENT_DISPLAY_NAME.ANTIGRAVITY,
-    [CLIENT.ANTIGRAVITY_CLI]: CLIENT_DISPLAY_NAME.ANTIGRAVITY_CLI,
-    [CLIENT.CLAUDE_CODE]: CLIENT_DISPLAY_NAME.CLAUDE_CODE,
-    [CLIENT.CLAUDE_DESKTOP]: CLIENT_DISPLAY_NAME.CLAUDE_DESKTOP,
-    [CLIENT.CLAUDE_TEAMS_ENTERPRISE]: CLIENT_DISPLAY_NAME.CLAUDE_TEAMS_ENTERPRISE,
-    [CLIENT.CODEX]: CLIENT_DISPLAY_NAME.CODEX,
-    [CLIENT.CURSOR]: CLIENT_DISPLAY_NAME.CURSOR,
-    [CLIENT.VSCODE]: CLIENT_DISPLAY_NAME.VSCODE,
-    [CLIENT.WINDSURF]: CLIENT_DISPLAY_NAME.WINDSURF,
-    [CLIENT.GOOSE]: CLIENT_DISPLAY_NAME.GOOSE,
-    [CLIENT.CHATGPT]: CLIENT_DISPLAY_NAME.CHATGPT,
-    [CLIENT.JUNIE]: CLIENT_DISPLAY_NAME.JUNIE,
-    [CLIENT.JETBRAINS]: CLIENT_DISPLAY_NAME.JETBRAINS,
-    [CLIENT.GEMINI]: CLIENT_DISPLAY_NAME.GEMINI,
-    [CLIENT.OPENCODE]: CLIENT_DISPLAY_NAME.OPENCODE,
-  };
-  return mapping[clientId];
+  return DISPLAY_NAME_BY_ID[clientId];
 }

--- a/packages/mcp-config-schema/src/registry.ts
+++ b/packages/mcp-config-schema/src/registry.ts
@@ -19,40 +19,7 @@ import {
   GeminiConfigBuilder,
   OpenCodeConfigBuilder,
 } from './builders/index.js';
-import chatgptConfig from '../configs/chatgpt.json';
-import claudeCodeConfig from '../configs/claude-code.json';
-import claudeDesktopConfig from '../configs/claude-desktop.json';
-import claudeTeamsEnterpriseConfig from '../configs/claude-teams-enterprise.json';
-import codexConfig from '../configs/codex.json';
-import cursorConfig from '../configs/cursor.json';
-import cursorAgentConfig from '../configs/cursor-agent.json';
-import gooseConfig from '../configs/goose.json';
-import vscodeConfig from '../configs/vscode.json';
-import windsurfConfig from '../configs/windsurf.json';
-import junieConfig from '../configs/junie.json';
-import jetbrainsConfig from '../configs/jetbrains.json';
-import geminiConfig from '../configs/gemini.json';
-import opencodeConfig from '../configs/opencode.json';
-import antigravityConfig from '../configs/antigravity.json';
-import antigravityCliConfig from '../configs/antigravity-cli.json';
-const allConfigs = [
-  antigravityConfig,
-  antigravityCliConfig,
-  chatgptConfig,
-  claudeCodeConfig,
-  claudeDesktopConfig,
-  claudeTeamsEnterpriseConfig,
-  codexConfig,
-  cursorConfig,
-  cursorAgentConfig,
-  gooseConfig,
-  vscodeConfig,
-  windsurfConfig,
-  junieConfig,
-  jetbrainsConfig,
-  geminiConfig,
-  opencodeConfig,
-];
+import { allClientConfigs as allConfigs } from './clients.generated.js';
 
 export class MCPConfigRegistry {
   private configs: Map<ClientId, MCPClientConfig> = new Map();

--- a/packages/mcp-config-schema/src/schemas.ts
+++ b/packages/mcp-config-schema/src/schemas.ts
@@ -1,23 +1,7 @@
 import { z } from 'zod';
+import { CLIENT_IDS } from './clients.generated.js';
 export const PlatformSchema = z.enum(['darwin', 'linux', 'win32']);
-export const ClientIdSchema = z.enum([
-  'antigravity',
-  'antigravity-cli',
-  'claude-code',
-  'vscode',
-  'claude-desktop',
-  'claude-teams-enterprise',
-  'cursor',
-  'cursor-agent',
-  'goose',
-  'windsurf',
-  'chatgpt',
-  'codex',
-  'junie',
-  'jetbrains',
-  'gemini',
-  'opencode',
-]);
+export const ClientIdSchema = z.enum(CLIENT_IDS);
 
 export const ServerTypeSchema = z.enum(['http', 'stdio']);
 

--- a/packages/mcp-config-schema/test/clients-generated.test.ts
+++ b/packages/mcp-config-schema/test/clients-generated.test.ts
@@ -1,0 +1,52 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { CLIENT, CLIENT_IDS, DISPLAY_NAME_BY_ID, allClientConfigs } from '../src/clients.generated';
+import { getDisplayName } from '../src/constants';
+import { MCPConfigRegistry } from '../src/registry';
+
+/**
+ * Guards the single-source-of-truth invariant: configs/*.json is authoritative,
+ * and src/clients.generated.ts is derived from it via `npm run generate:clients`.
+ * If these fail, the generated file is stale — regenerate it.
+ */
+describe('clients.generated.ts stays in sync with configs/', () => {
+  const configsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'configs');
+  const configFiles = readdirSync(configsDir)
+    .filter((f) => f.endsWith('.json'))
+    .sort();
+  const configs = configFiles.map((file) => ({
+    file,
+    base: file.replace(/\.json$/, ''),
+    ...(JSON.parse(readFileSync(join(configsDir, file), 'utf8')) as {
+      id: string;
+      displayName: string;
+    }),
+  }));
+
+  it('every config filename matches its id', () => {
+    for (const c of configs) {
+      expect(c.id, `${c.file} id`).toBe(c.base);
+    }
+  });
+
+  it('CLIENT_IDS covers exactly the config files', () => {
+    expect([...CLIENT_IDS].sort()).toEqual(configs.map((c) => c.id).sort());
+  });
+
+  it('allClientConfigs has one entry per config file', () => {
+    expect(allClientConfigs).toHaveLength(configs.length);
+    const registry = new MCPConfigRegistry();
+    expect(registry.getAllConfigs()).toHaveLength(configs.length);
+  });
+
+  it('CLIENT, display names, and getDisplayName derive from each config', () => {
+    const clientValues = Object.values(CLIENT) as string[];
+    for (const c of configs) {
+      expect(clientValues, `CLIENT missing ${c.id}`).toContain(c.id);
+      expect(DISPLAY_NAME_BY_ID[c.id as keyof typeof DISPLAY_NAME_BY_ID]).toBe(c.displayName);
+      expect(getDisplayName(c.id as (typeof CLIENT)[keyof typeof CLIENT])).toBe(c.displayName);
+    }
+  });
+});

--- a/packages/mcp-config-schema/test/registry.test.ts
+++ b/packages/mcp-config-schema/test/registry.test.ts
@@ -33,7 +33,7 @@ describe('MCPConfigRegistry', () => {
     it('should load VS Code config', () => {
       const config = registry.getConfig(CLIENT.VSCODE);
       expect(config).toBeDefined();
-      expect(config?.displayName).toBe('Visual Studio Code');
+      expect(config?.displayName).toBe('VS Code');
       expect(config?.configStructure.serversPropertyName).toBe('servers');
     });
 


### PR DESCRIPTION
## Summary

Makes `configs/*.json` the single source of truth for client identity and **generates** the previously hand-maintained constants from it.

A single client id was restated in ~8 places (filename, config `id`/`name`/`displayName`, `CLIENT`, `CLIENT_DISPLAY_NAME`, `getDisplayName`, the `ClientIdSchema` enum, and the registry import list). A new `scripts/generate-clients.ts` reads the config files and emits `src/clients.generated.ts`; `constants.ts`, `schemas.ts`, and `registry.ts` now consume it.

**Adding a client is now:** drop one JSON file + `npm run generate`.

## What this fixes

The duplication had already drifted:
- `cursor-agent` was registered in the schema enum and the registry but missing from `CLIENT` / `CLIENT_DISPLAY_NAME`.
- The VS Code display name diverged between the config and the constant. Unified to the conventional short form **VS Code**, sourced from the config.

## Guard rails

`test/clients-generated.test.ts` fails if the generated file is stale, if a config filename does not match its `id`, or if any display name drifts from its config. Regeneration is idempotent.

## Public API

Unchanged — `CLIENT`, `CLIENT_DISPLAY_NAME`, `getDisplayName`, `ClientId`, and `ClientIdSchema` keep the same shapes.

## Verification

`npm run build`, lint, typecheck, and 289 tests all pass.

> Overlaps with #110 (Antigravity CLI) on constants/schemas/registry, so merge order matters: merge #110 first and this regenerates to include it, or merge this first and #110 collapses to add-JSON + regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
