### PR TITLE
chore: ignore release-it major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # @release-it-plugins/lerna-changelog only peers release-it ^17-19; there is
+      # no release-it 20-compatible version yet, so a major bump breaks `npm ci`.
+      - dependency-name: "release-it"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Adds a Dependabot ignore rule for `release-it` major-version bumps.

The grouped dev-dependency PR bumped `release-it` 19 → 20, but `@release-it-plugins/lerna-changelog` (latest 8.0.1) peers `release-it@^17-19` — there is no release-it-20-compatible version yet, so `npm ci` fails with ERESOLVE. This rule holds `release-it` at v19 (the other dev-dependency updates are unaffected) until the plugin supports v20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
