### PR TITLE
fix: drop dead result initializer (no-useless-assignment)

### DIFF
--- a/packages/mcp-config-schema/src/builders/BaseConfigBuilder.ts
+++ b/packages/mcp-config-schema/src/builders/BaseConfigBuilder.ts
@@ -239,7 +239,7 @@ export abstract class BaseConfigBuilder<TConfig extends MCPConfig = MCPConfig> {
     const validatedOptions = validateConnectionOptions(options);
     const includeRootObject = validatedOptions.includeRootObject !== false;
 
-    let result: Record<string, unknown> = {};
+    let result: Record<string, unknown>;
 
     if (validatedOptions.transport === 'stdio') {
       result = this.buildStdioConfig(validatedOptions, includeRootObject);


### PR DESCRIPTION
## Summary

Removes a dead initializer (`let result: Record<string, unknown> = {}`) in `BaseConfigBuilder.buildConfiguration` — `result` is unconditionally reassigned in every non-throwing branch, so the `{}` is never read. A newer ESLint (incoming via the dev-dependency bump in #114) flags this under `no-useless-assignment`, breaking lint. TypeScript still treats `result` as definitely assigned before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
