### PR TITLE
chore: defer typescript and eslint major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,10 @@ updates:
       # no release-it 20-compatible version yet, so a major bump breaks `npm ci`.
       - dependency-name: "release-it"
         update-types: ["version-update:semver-major"]
+      # TypeScript and ESLint majors require deliberate migrations (tsconfig
+      # deprecations, new lint rules) — adopt them in dedicated PRs, not a
+      # grouped dev-dependency bump.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Defers `typescript` and `eslint` major-version bumps in Dependabot (alongside the existing `release-it` rule). #114 bundled `typescript` 5.8 → 6.0 and `eslint` → 10, both breaking majors (tsconfig deprecation errors, new lint rules) that warrant dedicated migration PRs rather than a grouped dev-dependency bump. With these ignored, Dependabot drops them from the group, leaving the ~12 safe updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
