### PR TITLE
fix: realign @eslint/js to v9 (restore npm install/publish)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+      # @eslint/* packages release in lockstep with eslint; pin the whole family
+      # to one major so a sub-package (e.g. @eslint/js) cannot desync from eslint.
+      - dependency-name: "@eslint/*"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.3",
         "@release-it-plugins/lerna-changelog": "^8.0.1",
         "@release-it-plugins/workspaces": "^5.0.3",
         "@types/node": "^25.9.1",
@@ -727,24 +727,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -5052,19 +5044,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.3",
     "@release-it-plugins/lerna-changelog": "^8.0.1",
     "@release-it-plugins/workspaces": "^5.0.3",
     "@types/node": "^25.9.1",


### PR DESCRIPTION
## Summary

Restores a coherent ESLint dependency family so `npm install` / `release-it` work again on `main`.

Dependabot #117 bumped `@eslint/js` to `^10.0.1` while `eslint` stayed at `^9.39.4` (its major was deferred). `@eslint/js` and `eslint` release in lockstep (`@eslint/js@10` requires `eslint@^10`), so a fresh resolve — `npm install`, and the `npm install --package-lock-only` that `release-it` runs — failed with ERESOLVE. CI passed only because `npm ci` tolerated the optional peer from the committed lockfile.

- Realign `@eslint/js` to `^9.39.3` (matching `eslint@9`) and regenerate the lockfile.
- Broaden the Dependabot ignore to the whole `@eslint/*` family so a sub-package cannot desync from `eslint` again while the ESLint 10 major stays deferred.

Adopting ESLint 10 remains a deliberate future migration (it also pulls in `@typescript-eslint` v9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
