### PR TITLE
feat: add managed setup URLs

### DIFF
--- a/packages/mcp-config-glean/README.md
+++ b/packages/mcp-config-glean/README.md
@@ -51,10 +51,27 @@ import { GLEAN_REGISTRY_OPTIONS, GLEAN_ENV } from '@gleanwork/mcp-config-glean';
 GLEAN_REGISTRY_OPTIONS.tokenEnvVarName   // 'GLEAN_API_TOKEN'
 GLEAN_REGISTRY_OPTIONS.commandBuilder    // Functions to generate CLI commands
 GLEAN_REGISTRY_OPTIONS.serverNameBuilder // Callback that prefixes server names with glean_
+GLEAN_REGISTRY_OPTIONS.managedSetupUrls  // Admin setup destinations for managed clients
 
 // Environment variable names
 GLEAN_ENV.SERVER_URL // 'GLEAN_SERVER_URL'
 GLEAN_ENV.API_TOKEN  // 'GLEAN_API_TOKEN'
+```
+
+The Glean registry provides managed setup destinations for ChatGPT,
+Claude Teams/Enterprise, and Cursor Team:
+
+```typescript
+const registry = createGleanRegistry();
+
+registry.getManagedSetupUrl('chatgpt');
+// https://chatgpt.com/admin/apps?tab=available&q=glean
+
+registry.getManagedSetupUrl('claude-teams-enterprise');
+// https://claude.ai/directory/connectors/glean
+
+registry.getManagedSetupUrl('cursor-team');
+// https://cursor.com/dashboard/integrations
 ```
 
 #### Helper Functions

--- a/packages/mcp-config-glean/src/index.ts
+++ b/packages/mcp-config-glean/src/index.ts
@@ -38,6 +38,11 @@ export const GLEAN_ENV = {
  */
 export const GLEAN_REGISTRY_OPTIONS: RegistryOptions = {
   tokenEnvVarName: GLEAN_ENV.API_TOKEN,
+  managedSetupUrls: {
+    chatgpt: 'https://chatgpt.com/admin/apps?tab=available&q=glean',
+    'claude-teams-enterprise': 'https://claude.ai/directory/connectors/glean',
+    'cursor-team': 'https://cursor.com/dashboard/integrations',
+  },
   commandBuilder: {
     http: (clientId, options) => {
       if (!options.serverUrl) return null;

--- a/packages/mcp-config-glean/test/index.test.ts
+++ b/packages/mcp-config-glean/test/index.test.ts
@@ -79,6 +79,27 @@ describe('@gleanwork/mcp-config', () => {
         })
       ).toBe('glean_analytics');
     });
+
+    it('defines managed setup URLs for supported web clients', () => {
+      const registry = createGleanRegistry();
+
+      expect(GLEAN_REGISTRY_OPTIONS.managedSetupUrls).toEqual({
+        chatgpt: 'https://chatgpt.com/admin/apps?tab=available&q=glean',
+        'claude-teams-enterprise': 'https://claude.ai/directory/connectors/glean',
+        'cursor-team': 'https://cursor.com/dashboard/integrations',
+      });
+
+      expect(registry.getManagedSetupUrl('chatgpt')).toBe(
+        'https://chatgpt.com/admin/apps?tab=available&q=glean'
+      );
+      expect(registry.getManagedSetupUrl('claude-teams-enterprise')).toBe(
+        'https://claude.ai/directory/connectors/glean'
+      );
+      expect(registry.getManagedSetupUrl('cursor-team')).toBe(
+        'https://cursor.com/dashboard/integrations'
+      );
+      expect(registry.getManagedSetupUrl('copilot-studio')).toBeUndefined();
+    });
   });
 
   describe('GLEAN_ENV', () => {

--- a/packages/mcp-config-schema/CLIENTS.md
+++ b/packages/mcp-config-schema/CLIENTS.md
@@ -794,7 +794,7 @@ EXAMPLE_API_KEY = "your-api-key"
 
 - **Configuration**: Centrally managed
 - **Connection Type**: HTTP only (managed)
-- **Documentation**: [Link](https://cursor.com/dashboard/integrations)
+- **Documentation**: [Link](https://cursor.com/docs/mcp#team-mcp-distribution)
 - **Auth Support**: Token, OAuth DCR
 - **Notes**: Cursor Team MCP servers are centrally managed by team admins through the Cursor dashboard web UI. This setup path does not use a user's local Cursor configuration file.
 
@@ -814,7 +814,7 @@ EXAMPLE_API_KEY = "your-api-key"
   "supportedPlatforms": [],
   "configFormat": "json",
   "configPath": {},
-  "documentationUrl": "https://cursor.com/dashboard/integrations",
+  "documentationUrl": "https://cursor.com/docs/mcp#team-mcp-distribution",
   "configStructure": {
     "serversPropertyName": ""
   },

--- a/packages/mcp-config-schema/README.md
+++ b/packages/mcp-config-schema/README.md
@@ -205,6 +205,19 @@ for (const type of CLIENT_TYPES) {
 
 Installability is a separate axis (`userConfigurable`): user-installable clients vs. centrally managed ones.
 
+Consumers can provide setup destinations for centrally managed clients without
+adding vendor-specific URLs to the shared client metadata:
+
+```typescript
+const registry = new MCPConfigRegistry({
+  managedSetupUrls: {
+    'cursor-team': 'https://example.com/admin/mcp',
+  },
+});
+
+registry.getManagedSetupUrl('cursor-team'); // https://example.com/admin/mcp
+```
+
 ### Generate Configurations
 
 ```typescript

--- a/packages/mcp-config-schema/configs/cursor-team.json
+++ b/packages/mcp-config-schema/configs/cursor-team.json
@@ -10,7 +10,7 @@
   "supportedPlatforms": [],
   "configFormat": "json",
   "configPath": {},
-  "documentationUrl": "https://cursor.com/dashboard/integrations",
+  "documentationUrl": "https://cursor.com/docs/mcp#team-mcp-distribution",
   "configStructure": {
     "serversPropertyName": ""
   },

--- a/packages/mcp-config-schema/src/registry.ts
+++ b/packages/mcp-config-schema/src/registry.ts
@@ -118,6 +118,23 @@ export class MCPConfigRegistry {
     return this.configs.get(clientId);
   }
 
+  /**
+   * Get the consumer-provided setup URL for a centrally managed client.
+   *
+   * Managed setup URLs are supplied through {@link RegistryOptions} rather
+   * than static client metadata so vendor-specific destinations remain out of
+   * the shared client configuration schema.
+   *
+   * @param clientId - The client to get a managed setup URL for
+   * @returns The setup URL, or undefined when none is configured
+   */
+  getManagedSetupUrl(clientId: ClientId): string | undefined {
+    if (!this.configs.has(clientId)) {
+      return undefined;
+    }
+    return this.options.managedSetupUrls?.[clientId];
+  }
+
   getAllConfigs(): MCPClientConfig[] {
     return Array.from(this.configs.values());
   }

--- a/packages/mcp-config-schema/src/types.ts
+++ b/packages/mcp-config-schema/src/types.ts
@@ -76,6 +76,23 @@ export interface RegistryOptions {
   /** NPM package for stdio server (e.g., '@my-org/mcp-server') */
   serverPackage?: string;
   /**
+   * Consumer-specific setup URLs for centrally managed clients.
+   *
+   * Use this for web destinations where an administrator configures an MCP
+   * server. These URLs are separate from client documentation and native
+   * one-click protocol handlers.
+   *
+   * @example
+   * ```typescript
+   * const registry = new MCPConfigRegistry({
+   *   managedSetupUrls: {
+   *     'cursor-team': 'https://example.com/admin/mcp',
+   *   },
+   * });
+   * ```
+   */
+  managedSetupUrls?: Partial<Record<ClientId, string>>;
+  /**
    * Custom command builders for clients without native CLI support.
    * Native CLI clients (VS Code, Claude Code, Codex) use their built-in commands.
    * For other clients, provide custom callbacks to generate installation commands.

--- a/packages/mcp-config-schema/test/browser-build.test.ts
+++ b/packages/mcp-config-schema/test/browser-build.test.ts
@@ -66,6 +66,17 @@ describe('Browser Build', () => {
     expect(cursorConfig?.displayName).toBe('Cursor');
   });
 
+  it('MCPConfigRegistry exposes consumer-provided managed setup URLs', () => {
+    const registry = new browserExports.MCPConfigRegistry({
+      managedSetupUrls: {
+        'cursor-team': 'https://example.com/admin/mcp',
+      },
+    });
+
+    expect(registry.getManagedSetupUrl('cursor-team')).toBe('https://example.com/admin/mcp');
+    expect(registry.getManagedSetupUrl('chatgpt')).toBeUndefined();
+  });
+
   it('Registry builders can generate configurations in browser', () => {
     const registry = new browserExports.MCPConfigRegistry();
     const builder = registry.createBuilder('cursor');

--- a/packages/mcp-config-schema/test/registry.test.ts
+++ b/packages/mcp-config-schema/test/registry.test.ts
@@ -43,10 +43,47 @@ describe('MCPConfigRegistry', () => {
       expect(config?.transports).toEqual(['stdio', 'http']);
     });
 
+    it('should load Cursor Team with its public documentation URL', () => {
+      const config = registry.getConfig(CLIENT.CURSOR_TEAM);
+      expect(config?.documentationUrl).toBe('https://cursor.com/docs/mcp#team-mcp-distribution');
+    });
+
     it('should load Goose config with YAML format', () => {
       const config = registry.getConfig(CLIENT.GOOSE);
       expect(config).toBeDefined();
       expect(config?.configFormat).toBe('yaml');
+    });
+  });
+
+  describe('managed setup URLs', () => {
+    it('does not define vendor-specific setup URLs by default', () => {
+      expect(registry.getManagedSetupUrl(CLIENT.CHATGPT)).toBeUndefined();
+      expect(registry.getManagedSetupUrl(CLIENT.CLAUDE_TEAMS_ENTERPRISE)).toBeUndefined();
+      expect(registry.getManagedSetupUrl(CLIENT.CURSOR_TEAM)).toBeUndefined();
+    });
+
+    it('returns consumer-provided setup URLs', () => {
+      const registryWithManagedSetup = new MCPConfigRegistry({
+        managedSetupUrls: {
+          [CLIENT.CURSOR_TEAM]: 'https://example.com/admin/mcp',
+        },
+      });
+
+      expect(registryWithManagedSetup.getManagedSetupUrl(CLIENT.CURSOR_TEAM)).toBe(
+        'https://example.com/admin/mcp'
+      );
+      expect(registryWithManagedSetup.getManagedSetupUrl(CLIENT.CHATGPT)).toBeUndefined();
+    });
+
+    it('returns undefined for an unknown client', () => {
+      const invalidClient = 'unknown' as unknown as ClientId;
+      const registryWithManagedSetup = new MCPConfigRegistry({
+        managedSetupUrls: {
+          [CLIENT.CURSOR_TEAM]: 'https://example.com/admin/mcp',
+        },
+      });
+
+      expect(registryWithManagedSetup.getManagedSetupUrl(invalidClient)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- add a generic managed setup URL option and registry accessor
- configure Glean-specific setup links for ChatGPT, Claude Teams/Enterprise, and Cursor Team only in mcp-config-glean
- restore Cursor Team documentationUrl to the public Cursor documentation
- document and test the generic and Glean-specific behavior, including the browser registry export

## Testing

- npm run build
- npm run test:all (23 test files, 308 tests)